### PR TITLE
Feature/problem models: Incr. db update support, bug fixes, and clean up

### DIFF
--- a/data/data_process.py
+++ b/data/data_process.py
@@ -12,6 +12,7 @@ Options:
 '''
 from __future__ import print_function
 
+import io
 import json
 import logging
 import os
@@ -84,7 +85,7 @@ def decode(json_path, *args, **options):
     # Load raw json_data from each of the json_paths
     json_data = []
     for path in json_paths:
-        with open(path) as json_file:
+        with io.open(path) as json_file:
             # TODO: May need to change this to load incrementally in the future
             json_data.append(json.load(json_file))
 

--- a/data/data_process.py
+++ b/data/data_process.py
@@ -34,6 +34,7 @@ def decode_problems(json_data):
     Resets tracking of updates via the Trackable metaclass each time it
     is called.
     '''
+    Trackable.register_existing()
     Trackable.clear_updates()
 
     for json_data_load in json_data:

--- a/intertwine/problems/models.py
+++ b/intertwine/problems/models.py
@@ -99,7 +99,7 @@ class Trackable(DeclarativeMeta):
         in the database registered. If a class is not Trackable, a
         TypeError is raised.
         '''
-        engine = create_engine(DevConfig.DATABASE, echo=True)
+        engine = create_engine(DevConfig.DATABASE)
         Session = sessionmaker(bind=engine)
         session = Session()
         classes = meta._classes.values() if len(args) == 0 else args

--- a/intertwine/problems/models.py
+++ b/intertwine/problems/models.py
@@ -672,7 +672,7 @@ class Problem(AutoTableMixin, BaseProblemModel):
             'narrower': ('scoped', 'self', 'adjacent_problem', 'broader'),
         }
         assert connections_name in derived_vars
-        conn_type, p_a, p_b, inverse_type = derived_vars[connections_name]
+        conn_type, p_a, p_b, inverse_name = derived_vars[connections_name]
         connections = getattr(self, connections_name)
 
         for connection_data in connections_data:
@@ -687,7 +687,7 @@ class Problem(AutoTableMixin, BaseProblemModel):
                 problem_scope=self)
             if connection not in connections:
                 connections.append(connection)
-                getattr(adjacent_problem, inverse_type).append(connection)
+                getattr(adjacent_problem, inverse_name).append(connection)
                 self._modified.add(adjacent_problem)
 
         if len(self._modified) > 0:


### PR DESCRIPTION
# Highlights

1. Incremental database updates are now supported. This requires registering all existing instances in the database with Trackable.register_existing() prior to loading json data in decode. (See Notes below.)
2. To aid with testing, an erase_data() function and a Trackable.clear_instances() method were added.
3. Removed 'key' parameter from Trackable.__call__() since it was getting in the way of expected behavior when using a Trackable class's constructor (e.g. Problem('new prob name')) and it was unnecessary as a Trackable class can (and now must) implement a create_key() method that returns a registry key based on the class's constructor input.
4.  On ProblemConnection, replaced all references to self.problem_a and self.problem_b with self.driver/self.broader and self.impact/self.narrower as appropriate based on self.connection_type. This fixed a number of bugs that emerged when reconstructing the Trackable registry from the database.
5. Miscellaneous cleanup of logic and documentation 

# Notes

I initially embedded database session creation within the functions/methods that needed to access the database, but I learned the hard way how this can easily lead to many insidious bugs due to different objects being associated with different sessions. The best way to handle this might be to create a DataProcessSession class as a singleton that only creates a new session the first time it is called.

However, to keep things simple for now, I ended up stripping out the database session creation and adding session as a parameter to the functions/methods that need it. These include erase_data(), Trackable.register_existing() and decode(), which calls Trackable.register_existing() prior to loading json since Trackable needs to be up-to-date in order for decode to work properly. 

# Testing

'''Create the session:'''
from sqlalchemy import create_engine
from sqlalchemy.orm import sessionmaker
from intertwine.config import DevConfig
engine = create_engine(DevConfig.DATABASE)
Session = sessionmaker(bind=engine)
s = Session()

'''Load modules to be tested:'''
from intertwine.problems.models import *
from data.data_process import *

'''Initial data load:'''
u0 = decode(s, 'data/problems/problems00.json')
for updates in u0.values():
    s.add_all(updates)

s.commit()

'''You can either:
a) Proceed with more data loads now
b) Kill the server, restart tmuxinator, and create a new session
   before the next decode
c) Simulate b's impact on Trackable by clearing it:'''
Trackable.clear_instances()

'''Next data load:'''
u1 = decode(s, 'data/problems/problems01.json')
for updates in u1.values():
    s.add_all(updates)

s.commit()

'''Optional, as before:'''
Trackable.clear_instances() 

'''Next data load:'''
u2 = decode(s, 'data/problems/problems02.json')
for updates in u2.values():
    s.add_all(updates)

s.commit()

'''Retrieve data from the database:'''
p0 = s.query(Problem).filter_by(name='Poverty').one()
p1 = s.query(Problem).filter_by(name='Homelessness').one()
p2 = s.query(Problem).filter_by(name='Domestic Violence').one()

c1 = s.query(ProblemConnection).filter(
    ProblemConnection.connection_type == 'scoped',
    ProblemConnection.broader == p0,
    ProblemConnection.narrower == p1).one()

c2 = s.query(ProblemConnection).filter(
    ProblemConnection.connection_type == 'causal',
    ProblemConnection.driver == p2,
    ProblemConnection.impact == p1).one()

rs1 = s.query(ProblemConnectionRating).filter(
    ProblemConnectionRating.connection == c1)

for r in rs1:
    print(r)

rs2 = s.query(ProblemConnectionRating).filter(
    ProblemConnectionRating.connection == c2,
    ProblemConnectionRating.problem_scope == p1,
    ProblemConnectionRating.org_scope.is_(None),
    ProblemConnectionRating.geo_scope == 'United States/Texas/Austin')

for r in rs2:
    print(r)