### PR TITLE
Fixes broken tests

### DIFF
--- a/intertwine/auth/tests/test_auth_endpoints.py
+++ b/intertwine/auth/tests/test_auth_endpoints.py
@@ -31,7 +31,7 @@ def test_auth_admin_(options):
 
 @pytest.mark.unit
 @pytest.mark.smoke
-def test_table_generation(options):
+def test_auth_table_generation(options):
     '''Tests decoding incrementally'''
     import os
     from intertwine import create_app
@@ -46,4 +46,5 @@ def test_table_generation(options):
     app.config['SERVER_NAME'] = '{}:{}'.format(host, port)
 
     with app.app_context():
-        assert os.path.exists(filepath)
+        if not filepath.endswith('://'):
+            assert os.path.exists(filepath)

--- a/intertwine/problems/tests/test_models.py
+++ b/intertwine/problems/tests/test_models.py
@@ -33,17 +33,22 @@ def test_problem_connection_model(options):
     from intertwine import create_app
     from intertwine.config import ToxConfig
     from intertwine.problems import problems_db
-    from intertwine.problems.models import ProblemConnection as Model
+    from intertwine.problems.models import ProblemConnection, Problem
 
     app = create_app(ToxConfig)
     with app.app_context():
         session = problems_db.session
         assert session is not None
-        assert session.query(Model).all() == []
+        assert session.query(ProblemConnection).all() == []
         problem_name = 'testProblem'
-        problem = Model(problem_name)
-        session.add(problem)
+        problem1 = Problem(problem_name + '01')
+        problem2 = Problem(problem_name + '02')
+        connection = ProblemConnection('causal',problem1, problem2)
+        session.add(problem1)
+        session.add(problem2)
+        session.add(connection)
         session.commit()
-        assert session.query(Model).all() != []
-        query = session.query(Model).filter_by(name='testProblem')
-        assert problem in query.all()
+        assert session.query(Problem).all() != []
+        assert session.query(ProblemConnection).all() != []
+        query = session.query(ProblemConnection)
+        assert connection in query.all()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -45,4 +45,5 @@ def test_database_created(options):
     app.config['SERVER_NAME'] = '{}:{}'.format(host, port)
 
     with app.app_context():
-        assert os.path.exists(filepath)
+        if not filepath.endswith('://'):
+            assert os.path.exists(filepath)


### PR DESCRIPTION
In two of the tests, we were looking for a filepath, but our test database configuration has changed such that a we now store the database within memory as opposed to a file.  Consequently, filepaths are not valid.  TODO:  add more testing to validate that the database and its tables are formulated properly.

One of the failing tests incorrectly constructed a ProblemConnection.  This has been fixed.