### PR TITLE
 Implement aggregate rating caching

### DIFF
--- a/data/problems/problems03.json
+++ b/data/problems/problems03.json
@@ -1,14 +1,12 @@
 {
-    "Homelessness": {
-        "definition": "Homelessness is the condition of people without a regular dwelling",
-        "definition_url": "https://en.wikipedia.org/wiki/Homelessness",
+    "Substance Abuse": {
+        "definition": "Substance abuse is a patterned use of a drug in which the user consumes the substance in amounts or with methods which are harmful to themselves or others, and is a form of substance-related disorder",
+        "definition_url": "https://en.wikipedia.org/wiki/Substance_abuse",
         "images": [
-            "http://mediad.publicbroadcasting.net/p/kut/files/201206/Homeless%20in%20Line.JPG",
-            "http://healthnewstexas.com/wp-content/uploads/2011/03/Austin-Homeless.jpg"
         ],
         "drivers": [
             {
-                "adjacent_problem": "Mental Illness",
+                "adjacent_problem": "Depression",
                 "problem_connection_ratings": [
                     {
                         "rating": 4,
@@ -28,7 +26,7 @@
                 ]
             },
             {
-                "adjacent_problem": "Substance Abuse",
+                "adjacent_problem": "Stress",
                 "problem_connection_ratings": [
                     {
                         "rating": 4,
@@ -53,7 +51,7 @@
                 ]
             },
             {
-                "adjacent_problem": "Domestic Violence",
+                "adjacent_problem": "Peer Pressure",
                 "problem_connection_ratings": [
                     {
                         "rating": 4,
@@ -78,7 +76,7 @@
                 ]
             },
             {
-                "adjacent_problem": "Post-Traumatic Stress Disorder",
+                "adjacent_problem": "Low Self-Esteem",
                 "problem_connection_ratings": [
                     {
                         "rating": 3,
@@ -101,9 +99,11 @@
                         "geo_scope": "United States"
                     }
                 ]
-            },
+            }
+        ],
+        "impacts": [
             {
-                "adjacent_problem": "Broken Foster Care System",
+                "adjacent_problem": "Incarceration",
                 "problem_connection_ratings": [
                     {
                         "rating": 4,
@@ -111,27 +111,27 @@
                         "geo_scope": "United States/Texas/Austin"
                     },
                     {
-                        "rating": 2,
+                        "rating": 4,
                         "user_id": "brian@intertwine.io",
                         "geo_scope": "United States/Texas/Austin"
                     },
                     {
-                        "rating": 3,
+                        "rating": 4,
                         "user_id": "Donald.Christian@concordia.edu",
                         "geo_scope": "United States/Texas/Austin"
                     },
                     {
-                        "rating": 3,
+                        "rating": 4,
                         "user_id": "sapanadonde@hotmail.com",
                         "geo_scope": "United States"
                     }
                 ]
             },
             {
-                "adjacent_problem": "Lack of Affordable Housing",
+                "adjacent_problem": "Health Problems",
                 "problem_connection_ratings": [
                     {
-                        "rating": 2,
+                        "rating": 4,
                         "user_id": "eli@intertwine.io",
                         "geo_scope": "United States/Texas/Austin"
                     },
@@ -141,44 +141,19 @@
                         "geo_scope": "United States/Texas/Austin"
                     },
                     {
-                        "rating": 3,
+                        "rating": 4,
                         "user_id": "Donald.Christian@concordia.edu",
                         "geo_scope": "United States/Texas/Austin"
                     },
                     {
-                        "rating": 2,
+                        "rating": 3,
                         "user_id": "sapanadonde@hotmail.com",
                         "geo_scope": "United States"
                     }
                 ]
             },
             {
-                "adjacent_problem": "Criminalization of Poverty",
-                "problem_connection_ratings": [
-                    {
-                        "rating": 3,
-                        "user_id": "eli@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 2,
-                        "user_id": "brian@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 2,
-                        "user_id": "Donald.Christian@concordia.edu",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 2,
-                        "user_id": "sapanadonde@hotmail.com",
-                        "geo_scope": "United States"
-                    }
-                ]
-            },
-            {
-                "adjacent_problem": "Discrimination Against Ex-Convicts",
+                "adjacent_problem": "Criminal Careers",
                 "problem_connection_ratings": [
                     {
                         "rating": 2,
@@ -191,12 +166,139 @@
                         "geo_scope": "United States/Texas/Austin"
                     },
                     {
+                        "rating": 3,
+                        "user_id": "Donald.Christian@concordia.edu",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 4,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States"
+                    }
+                ]
+            },
+            {
+                "adjacent_problem": "Premature Death",
+                "problem_connection_ratings": [
+                    {
                         "rating": 2,
+                        "user_id": "eli@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "brian@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 1,
                         "user_id": "Donald.Christian@concordia.edu",
                         "geo_scope": "United States/Texas/Austin"
                     },
                     {
                         "rating": 2,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States"
+                    }
+                ]
+            },
+            {
+                "adjacent_problem": "Poor School Performance",
+                "problem_connection_ratings": [
+                    {
+                        "rating": 2,
+                        "user_id": "eli@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "brian@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 4,
+                        "user_id": "Donald.Christian@concordia.edu",
+                        "org_scope": "Concordia University",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States"
+                    },
+                    {
+                        "rating": 3,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "org_scope": "University of Texas",
+                        "geo_scope": "United States/Texas/Austin"
+                    }
+                ]
+            },
+            {
+                "adjacent_problem": "Healthcare Costs",
+                "problem_connection_ratings": [
+                    {
+                        "rating": 3,
+                        "user_id": "eli@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "brian@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "Donald.Christian@concordia.edu",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 1,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States/Texas"
+                    },
+                    {
+                        "rating": 3,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States"
+                    }
+                ]
+            },
+            {
+                "adjacent_problem": "Jail Costs",
+                "problem_connection_ratings": [
+                    {
+                        "rating": 3,
+                        "user_id": "eli@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "brian@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "Donald.Christian@concordia.edu",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 1,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States/Texas"
+                    },
+                    {
+                        "rating": 3,
                         "user_id": "sapanadonde@hotmail.com",
                         "geo_scope": "United States"
                     }
@@ -223,54 +325,12 @@
                     {
                         "rating": 1,
                         "user_id": "sapanadonde@hotmail.com",
-                        "geo_scope": "United States"
-                    }
-                ]
-            }
-        ],
-        "impacts": [
-            {
-                "adjacent_problem": "Emergency Room Costs",
-                "problem_connection_ratings": [
-                    {
-                        "rating": 4,
-                        "user_id": "eli@intertwine.io",
                         "geo_scope": "United States/Texas/Austin"
                     },
                     {
-                        "rating": 4,
-                        "user_id": "brian@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 4,
-                        "user_id": "Donald.Christian@concordia.edu",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 4,
+                        "rating": 2,
                         "user_id": "sapanadonde@hotmail.com",
-                        "geo_scope": "United States"
-                    }
-                ]
-            },
-            {
-                "adjacent_problem": "Law Enforcement Costs",
-                "problem_connection_ratings": [
-                    {
-                        "rating": 4,
-                        "user_id": "eli@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 3,
-                        "user_id": "brian@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 4,
-                        "user_id": "Donald.Christian@concordia.edu",
-                        "geo_scope": "United States/Texas/Austin"
+                        "geo_scope": "United States/Texas"
                     },
                     {
                         "rating": 3,
@@ -280,82 +340,7 @@
                 ]
             },
             {
-                "adjacent_problem": "Victimization by Violent Crime",
-                "problem_connection_ratings": [
-                    {
-                        "rating": 2,
-                        "user_id": "eli@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 2,
-                        "user_id": "brian@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 3,
-                        "user_id": "Donald.Christian@concordia.edu",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 4,
-                        "user_id": "sapanadonde@hotmail.com",
-                        "geo_scope": "United States"
-                    }
-                ]
-            },
-            {
-                "adjacent_problem": "Spread of Disease",
-                "problem_connection_ratings": [
-                    {
-                        "rating": 2,
-                        "user_id": "eli@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 2,
-                        "user_id": "brian@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 1,
-                        "user_id": "Donald.Christian@concordia.edu",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 2,
-                        "user_id": "sapanadonde@hotmail.com",
-                        "geo_scope": "United States"
-                    }
-                ]
-            },
-            {
-                "adjacent_problem": "Disenfranchisement",
-                "problem_connection_ratings": [
-                    {
-                        "rating": 2,
-                        "user_id": "eli@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 2,
-                        "user_id": "brian@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 3,
-                        "user_id": "Donald.Christian@concordia.edu",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 2,
-                        "user_id": "sapanadonde@hotmail.com",
-                        "geo_scope": "United States"
-                    }
-                ]
-            },
-            {
-                "adjacent_problem": "Hypothermia",
+                "adjacent_problem": "Homelessness",
                 "problem_connection_ratings": [
                     {
                         "rating": 1,
@@ -392,7 +377,7 @@
         ],
         "broader": [
             {
-                "adjacent_problem": "Poverty",
+                "adjacent_problem": "Escapism",
                 "problem_connection_ratings": [
                     {
                         "rating": 4,
@@ -417,7 +402,7 @@
                 ]
             },
             {
-                "adjacent_problem": "Social Injustice",
+                "adjacent_problem": "Abdication of Responsibility",
                 "problem_connection_ratings": [
                     {
                         "rating": 3,
@@ -442,7 +427,7 @@
                 ]
             },
             {
-                "adjacent_problem": "Economic Inequality",
+                "adjacent_problem": "Overindulgence",
                 "problem_connection_ratings": [
                     {
                         "rating": 3,
@@ -476,31 +461,6 @@
                     },
                     {
                         "rating": 3,
-                        "user_id": "brian@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 3,
-                        "user_id": "Donald.Christian@concordia.edu",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 2,
-                        "user_id": "sapanadonde@hotmail.com",
-                        "geo_scope": "United States"
-                    }
-                ]
-            },
-            {
-                "adjacent_problem": "Insufficient Safety Net",
-                "problem_connection_ratings": [
-                    {
-                        "rating": 2,
-                        "user_id": "eli@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 2,
                         "user_id": "brian@intertwine.io",
                         "geo_scope": "United States/Texas/Austin"
                     },
@@ -554,7 +514,7 @@
         ],
         "narrower": [
             {
-                "adjacent_problem": "Homeless Youth",
+                "adjacent_problem": "Alcoholism",
                 "problem_connection_ratings": [
                     {
                         "rating": 4,
@@ -579,7 +539,7 @@
                 ]
             },
             {
-                "adjacent_problem": "Homeless Veterans",
+                "adjacent_problem": "Heroin Use",
                 "problem_connection_ratings": [
                     {
                         "rating": 3,
@@ -604,7 +564,7 @@
                 ]
             },
             {
-                "adjacent_problem": "Homeless Elderly",
+                "adjacent_problem": "Prescription Drug Abuse",
                 "problem_connection_ratings": [
                     {
                         "rating": 3,
@@ -629,7 +589,7 @@
                 ]
             },
             {
-                "adjacent_problem": "Homeless Families",
+                "adjacent_problem": "Crack Cocaine Use",
                 "problem_connection_ratings": [
                     {
                         "rating": 3,
@@ -638,31 +598,6 @@
                     },
                     {
                         "rating": 3,
-                        "user_id": "brian@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 3,
-                        "user_id": "Donald.Christian@concordia.edu",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 2,
-                        "user_id": "sapanadonde@hotmail.com",
-                        "geo_scope": "United States"
-                    }
-                ]
-            },
-            {
-                "adjacent_problem": "Homeless Often Lack ID",
-                "problem_connection_ratings": [
-                    {
-                        "rating": 2,
-                        "user_id": "eli@intertwine.io",
-                        "geo_scope": "United States/Texas/Austin"
-                    },
-                    {
-                        "rating": 2,
                         "user_id": "brian@intertwine.io",
                         "geo_scope": "United States/Texas/Austin"
                     },
@@ -679,7 +614,32 @@
                 ]
             },
             {
-                "adjacent_problem": "Poor Health and Social Service Coordination for the Homeless",
+                "adjacent_problem": "Methamphetamine Use",
+                "problem_connection_ratings": [
+                    {
+                        "rating": 2,
+                        "user_id": "eli@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "brian@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 3,
+                        "user_id": "Donald.Christian@concordia.edu",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States"
+                    }
+                ]
+            },
+            {
+                "adjacent_problem": "Cocaine Use",
                 "problem_connection_ratings": [
                     {
                         "rating": 3,
@@ -714,7 +674,77 @@
                 ]
             },
             {
-                "adjacent_problem": "Lack of Standard Homeless Metrics",
+                "adjacent_problem": "Tobacco Use",
+                "problem_connection_ratings": [
+                    {
+                        "rating": 3,
+                        "user_id": "eli@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 1,
+                        "user_id": "brian@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 3,
+                        "user_id": "Donald.Christian@concordia.edu",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 3,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States/Texas"
+                    },
+                    {
+                        "rating": 4,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States"
+                    }
+                ]
+            },
+            {
+                "adjacent_problem": "Amphetamine Use",
+                "problem_connection_ratings": [
+                    {
+                        "rating": 3,
+                        "user_id": "eli@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 1,
+                        "user_id": "brian@intertwine.io",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 3,
+                        "user_id": "Donald.Christian@concordia.edu",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 2,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States/Texas/Austin"
+                    },
+                    {
+                        "rating": 3,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States/Texas"
+                    },
+                    {
+                        "rating": 4,
+                        "user_id": "sapanadonde@hotmail.com",
+                        "geo_scope": "United States"
+                    }
+                ]
+            },
+            {
+                "adjacent_problem": "Cannabis Use",
                 "problem_connection_ratings": [
                     {
                         "rating": 3,

--- a/intertwine/__init__.py
+++ b/intertwine/__init__.py
@@ -5,6 +5,7 @@ Base platform for intertwine.
 
 '''
 import flask
+from sassutils.wsgi import SassMiddleware
 from flask_bootstrap import Bootstrap
 
 from . import auth, main, problems, signup
@@ -39,6 +40,11 @@ def create_app(config):
         from flask_debugtoolbar import DebugToolbarExtension
         toolbar = DebugToolbarExtension()
 
+    # Auto-build SASS/SCSS for each request
+    app.wsgi_app = SassMiddleware(app.wsgi_app, {
+        __name__: ('static/sass', 'static/css', 'static/css')
+    })
+
     # We are using bootstrap for now
     Bootstrap(app)
 
@@ -47,6 +53,11 @@ def create_app(config):
     app.register_blueprint(auth.blueprint, url_prefix='/auth')
     app.register_blueprint(signup.blueprint, url_prefix='/signup')
     app.register_blueprint(problems.blueprint, url_prefix='/problems')
+
+    # Auto-build SASS/SCSS for each request
+    app.wsgi_app = SassMiddleware(app.wsgi_app, {
+        __name__: ('problems/static/sass', 'problems/static/css', 'problems/static/css')
+    })
 
     if app.config['DEBUG']:
         toolbar.init_app(app)

--- a/intertwine/problems/exceptions.py
+++ b/intertwine/problems/exceptions.py
@@ -63,5 +63,5 @@ class InvalidUser(DataProcessException):
     '''User {user!r} on rating of {connection!r} is not a valid.'''
 
 
-class InvalidProblemScope(DataProcessException):
-    '''{problem_scope!r} must be a problem on one end of {connection!r}.'''
+class InvalidProblemForConnection(DataProcessException):
+    '''{problem!r} must be a problem in {connection!r}.'''

--- a/intertwine/problems/exceptions.py
+++ b/intertwine/problems/exceptions.py
@@ -50,6 +50,15 @@ class InvalidProblemConnectionRating(DataProcessException):
     between 0 and 4 (inclusive).'''
 
 
+class InvalidAggregateConnectionRating(DataProcessException):
+    '''Aggregate rating of {rating} on {connection!r} is not valid. Must
+    be a Real number between 0 and 4 (inclusive).'''
+
+
+class InvalidAggregation(DataProcessException):
+    '''Aggregation '{aggregation}' is not valid. Must be 'strict'.'''
+
+
 class InvalidUser(DataProcessException):
     '''User {user!r} on rating of {connection!r} is not a valid.'''
 

--- a/intertwine/problems/static/css/general.css
+++ b/intertwine/problems/static/css/general.css
@@ -1,312 +1,288 @@
 
 
 body {
-	margin:0;
-	padding:0;
-	/*font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;*/
-	font-size:100%;
-	background-color:white; /* #EBF0FC #bed2fa; */
-	min-width:1em; /* preserves network structure */
+	margin: 0;
+	padding: 0;
+	/*font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;*/
+	font-size: 100%;
+	background-color: white; /* #EBF0FC #bed2fa; */
+	min-width: 1em; /* preserves network structure */
 	width: auto !important;  /* Firefox will set width as auto */
-    width:1000px;             /* As IE ignores !important it will set width as 1000px; */
+    width: 1000px;             /* As IE ignores !important it will set width as 1000px; */
 }
 
 header {
-	/*margin-top:5em;*/
-	margin-left:1em;
+	/*margin-top: 5em;*/
+	margin-left: 1em;
 }
 
 section {
-	color:#1A1A1A;
-	margin-top:1em;
-	/*background-color:white;*/
+	color: #1A1A1A;
+	margin-top: 1em;
+	/*background-color: white;*/
 	/*border: 0.05em solid #1A1A1A;*/
 }
 
 a {
-	text-decoration:none;
+	text-decoration: none;
 }
 
 a:hover {
 	text-decoration: underline;
-	color:#1A1A1A;
+	color: #1A1A1A;
 }
 
 h1 {
-	margin-top:0em;
-	margin-bottom:0em;
-	/*line-height:1.1;*/
+	margin-top: 0em;
+	margin-bottom: 0em;
+	/*line-height: 1.1;*/
 }
 
 h2 {
-	margin-top:0em;
-	margin-bottom:0em;
+	margin-top: 0em;
+	margin-bottom: 0em;
 }
 
 .page-title {
-	/*margin-top:0em;*/
-	font-size:1.5em;
+	/*margin-top: 0em;*/
+	font-size: 1.5em;
 }
 
 .page-scope {
-	font-size:0.8em;
-	/*padding-left:0.75em;*/
+	font-size: 0.8em;
+	/*padding-left: 0.75em;*/
 }
 
 .page-tagline {
-	margin-top:0.2em;
-	font-size:1.2em;
-	line-height:1;
-	text-align:left;
+	margin-top: 0.2em;
+	font-size: 1.2em;
+	line-height: 1;
+	text-align: left;
 }
 
 /* 320px */
 @media (min-width: 20em) {
     header, section {
-        font-size:1.2em;
+        font-size: 1.2em;
     }
 }
 
 /* 448px */
 @media (min-width: 28em) {
     header, section {
-        font-size:1.3em;
+        font-size: 1.3em;
     }
 }
 
 /* 512px */
 @media (min-width: 32em) {
     header, section {
-        font-size:1.5em;
+        font-size: 1.5em;
     }
 }
 
 /* 768px */
 @media (min-width: 48em) {
     header, section {
-        font-size:1.75em;
+        font-size: 1.75em;
     }
 }
 
 .nav-spacer {
-	padding:3em 0;
+	padding: 3em 0;
 }
 
 .h-x-small-spacer {
-	margin:0 0.0625em;
+	margin: 0 0.0625em;
 }
 
 .h-small-spacer {
-	margin:0 0.125em;
+	margin: 0 0.125em;
 }
 
 .h-medium-spacer {
-	margin:0 0.25em;
+	margin: 0 0.25em;
 }
 
 .h-large-spacer {
-	margin:0 0.5em;
+	margin: 0 0.5em;
 }
 
 .v-x-small-spacer {
-	margin:0.0625em 0;
+	margin: 0.0625em 0;
 }
 
 .v-small-spacer {
-	margin:0.125em 0;
+	margin: 0.125em 0;
 }
 
 .v-medium-spacer {
-	margin:0.25em 0;
+	margin: 0.25em 0;
 }
 
 .v-large-spacer {
-	margin:0.5em 0;
+	margin: 0.5em 0;
 }
 
 .v-1x-large-spacer {
-	margin:1.0em 0;
+	margin: 1.0em 0;
 }
 
 .v-2x-large-spacer {
-	margin:2.0em 0;
+	margin: 2.0em 0;
 }
 
 .v-3x-large-spacer {
-	margin:3.0em 0;
-}
-
-.xx-small-icon {
-	width:0.8em;
-	height:auto;
-	vertical-align:middle;
-}
-
-.x-small-icon {
-	width:1em;
-	height:auto;
-	vertical-align:middle;
-}
-
-.small-icon {
-	width:1.25em;
-	height:auto;
-	vertical-align:middle;
-}
-
-.medium-icon {
-	width:1.5em;
-	height:auto;
-	vertical-align:middle;
+	margin: 3.0em 0;
 }
 
 /* helper is used by an empty span to allow other images in the same div to be vertically aligned */
 .img-v-align-helper {
-	display:inline-block;
-	height:100%;
-	vertical-align:middle;
+	display: inline-block;
+	height: 100%;
+	vertical-align: middle;
 	margin: 0 auto;
 }
 
 .v-ghost-center-outer {
-	text-align:center;
+	text-align: center;
 
 	/*in case container may be narrower than content*/
-	white-space:nowrap;
+	white-space: nowrap;
 }
 
 .v-ghost-center-outer::before {
-	content:'';
-	display:inline-block;
-	height:100%;
-	vertical-align:middle;;
-	margin-right:-0.25em; /* Adjusts for spacing */
+	content: '';
+	display: inline-block;
+	height: 100%;
+	vertical-align: middle;;
+	margin-right: -0.25em; /* Adjusts for spacing */
 }
 
 .v-ghost-center-inner {
-	display:inline-block;
-	vertical-align:middle;
+	display: inline-block;
+	vertical-align: middle;
 }
 
 .v-ghost-center-before {
-	position:relative;
+	position: relative;
 }
 .v-ghost-center-before::before {
-	display:inline-block;
-	vertical-align:middle;
-	height:100%;
-	content:"";
-	margin-right:-1em;
+	display: inline-block;
+	vertical-align: middle;
+	height: 100%;
+	content: "";
+	margin-right: -1em;
 }
 .v-ghost-center-before div {
-	display:inline-block;
-	vertical-align:middle;
-	text-align:right;
-	width:95%;
+	display: inline-block;
+	vertical-align: middle;
+	text-align: right;
+	width: 95%;
 }
 
 .v-ghost-center-after {
-	position:relative;
+	position: relative;
 }
 .v-ghost-center-after::after {
-	display:inline-block;
-	vertical-align:middle;
-	height:100%;
-	content:"";
-	margin-left:-1em;
+	display: inline-block;
+	vertical-align: middle;
+	height: 100%;
+	content: "";
+	margin-left: -1em;
 }
 .v-ghost-center-after div {
-	display:inline-block;
-	vertical-align:middle;
-	width:95%;
+	display: inline-block;
+	vertical-align: middle;
+	width: 95%;
 }
 
 .center-outer {
-	position:relative;
+	position: relative;
 }
 
 .center-inner {
-	width:100%;
-	height:100%;
-	overflow:auto;
+	width: 100%;
+	height: 100%;
+	overflow: auto;
 	margin: auto;
-	position:absolute;
-	top:0;
-	left:0;
-	bottom:0;
-	right:0;
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
 }
 
 .v-align-outer {
-	display:table;
-	height:100%;
+	display: table;
+	height: 100%;
 	margin: 0 auto;
-/*	overflow:hidden; */
+/*	overflow: hidden; */
 }
 
 .v-align-inner {
-	display:table-cell;
-	vertical-align:middle;
+	display: table-cell;
+	vertical-align: middle;
 	margin: 0 auto;
 }
 
 .v-align-inner-top {
-	display:table-cell;
-	vertical-align:top;
+	display: table-cell;
+	vertical-align: top;
 	margin: 0 auto;
 }
 
 .v-align-inner-bottom {
-	display:table-cell;
-	vertical-align:bottom;
+	display: table-cell;
+	vertical-align: bottom;
 	margin: 0 auto;
 }
 
 .h-align-outer {
-	display:table;
-	width:100%;
+	display: table;
+	width: 100%;
 	margin: 0 auto;
-/*	overflow:hidden; */
+/*	overflow: hidden; */
 }
 
 .h-align-inner {
-	display:table-cell;
-	text-align:center;
+	display: table-cell;
+	text-align: center;
 	margin: 0 auto;
 }
 
 .h-align-inner-left {
-	display:table-cell;
-	text-align:left;
+	display: table-cell;
+	text-align: left;
 	margin: 0 auto;
 }
 
 .h-align-inner-right {
-	display:table-cell;
-	text-align:right;
+	display: table-cell;
+	text-align: right;
 	margin: 0 auto;
 }
 
 .center-outer {
-	display:table;
-	height:100%;
-	width:100%;
+	display: table;
+	height: 100%;
+	width: 100%;
 	margin: 0 auto;
 }
 
 .center-inner {
-	display:table-cell;
-	vertical-align:middle;
-	text-align:center;
+	display: table-cell;
+	vertical-align: middle;
+	text-align: center;
 	margin: 0 auto;
 }
 
 .h-resizable {
-	resize:horizontal;
+	resize: horizontal;
 }
 
 .not-resizable {
-	resize:none;
+	resize: none;
 }
 
 .invisible {
@@ -338,8 +314,8 @@ div.arrow-up {
 	border-left: 1em solid transparent;
 	border-right: 1em solid transparent;
 	border-bottom: 1em solid #1A1A1A;
-	margin-left:auto;
-	margin-right:auto;
+	margin-left: auto;
+	margin-right: auto;
 }
 
 div.arrow-down {
@@ -348,8 +324,8 @@ div.arrow-down {
 	border-left: 1em solid transparent;
 	border-right: 1em solid transparent;
 	border-top: 1em solid #1A1A1A;
-	margin-left:auto;
-	margin-right:auto;
+	margin-left: auto;
+	margin-right: auto;
 }
 
 .rotate {
@@ -367,7 +343,7 @@ div.arrow-down {
   transform-origin: 50% 50%;
 
   /* Should be unset in IE9+ I think. */
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+  filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=3);
 }
 
 .word-break {

--- a/intertwine/problems/static/css/network.css
+++ b/intertwine/problems/static/css/network.css
@@ -1,15 +1,15 @@
 .v-margin {
-    /*width:0.1em;*/
-    /*min-width:0em;*/
-    flex:1 1 0;
+    /*width: 0.1em;*/
+    /*min-width: 0em;*/
+    flex: 1 1 0;
 }
 
 .middle-network-area {
-    display:flex;
-    flex-flow:row nowrap;
-    justify-content:center;
-    align-items:center;
-    min-width:0;
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: center;
+    align-items: center;
+    min-width: 0;
 }
 
 
@@ -17,67 +17,67 @@
 
 
 .h-connection-label-container {
-    display:flex;
-    flex-flow:row nowrap;
-    justify-content:center;
-    align-items:center; /* vertically center icons (don't stretch) */
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: center;
+    align-items: center; /* vertically center icons (don't stretch) */
 }
 
 .connection-label {
-    font-size:2em;
-    /*margin:0.1em;*/
+    font-size: 2em;
+    /*margin: 0.1em;*/
 }
 
 .h-problem-area {
-    display:flex;
-    flex-flow:row nowrap;
-    justify-content:center;
-    align-items:center;
-    width:100%;
-    min-width:15em;
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    min-width: 15em;
 }
 .h-problem-area > div > a {
-    display:none;
+    display: none;
 }
 .h-problem-area:hover > div > a {
-    display:block;
+    display: block;
 }
 
 .h-arrow-container {
-    width:2em;
-    min-width:2em;
-    max-width:2em;
-    flex:0 0 0;
+    width: 2em;
+    min-width: 2em;
+    max-width: 2em;
+    flex: 0 0 0;
 }
 
 .h-problem-scroll-container {
-    display:flex;
-    flex-flow:row nowrap;
-    justify-content:center;
-    align-items:center;
-    flex:8 8 4;
-    overflow-x:auto;
-    overflow-y:hidden;
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: center;
+    align-items: center;
+    flex: 8 8 4;
+    overflow-x: auto;
+    overflow-y: hidden;
 }
 
 .h-problem-scroll {
-    display:flex;
-    flex-direction:row;
-    justify-content:flex-start;
-    align-items:flex-start;
-    overflow-x:auto;
-    overflow-y:hidden;
-    /*resize:horizontal;*/
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: flex-start;
+    overflow-x: auto;
+    overflow-y: hidden;
+    /*resize: horizontal;*/
 }
 
 .broader-scroll {
     /* nowrap */
-    flex-wrap:nowrap;
-    align-items:flex-end;
+    flex-wrap: nowrap;
+    align-items: flex-end;
 
     /* wrap */
-    /*flex-wrap:wrap-reverse;*/
-    /*justify-content:center;*/
+    /*flex-wrap: wrap-reverse;*/
+    /*justify-content: center;*/
 }
 
 .narrower-scroll {
@@ -86,43 +86,43 @@
 
     /* wrap */
     /*flex-wrap: wrap;*/
-    /*justify-content:center;*/
+    /*justify-content: center;*/
 }
 
 .h-problem {
-    min-width:6em;
-    max-width:16em;
-    /*max-height:8.25em;*/
-    margin:0 0.5em;
-    overflow:hidden;
-    resize:none;
-    text-align:center;
+    min-width: 6em;
+    max-width: 16em;
+    /*max-height: 8.25em;*/
+    margin: 0 0.5em;
+    overflow: hidden;
+    resize: none;
+    text-align: center;
 }
-.h-problem:first-child {
-    margin-left:0;
+.h-problem: first-child {
+    margin-left: 0;
 }
-.h-problem:last-child {
-    margin-right:0;
+.h-problem: last-child {
+    margin-right: 0;
 }
 
 .broader-problem {
-    margin-top:0.5em;
+    margin-top: 0.5em;
 }
 
 .narrower-problem {
-    margin-bottom:0.5em;
+    margin-bottom: 0.5em;
 }
 
 .h-problem-link-container {
-    font-size:1em;
-    line-height:1.1em;
+    font-size: 1em;
+    line-height: 1.1em;
     /* 3 lines per problem name */
-    max-height:3.3em;
-    overflow:hidden;
-    overflow-x:hidden;
-    overflow-y:auto;
-    text-align:center;
-    /*white-space:nowrap;*/
+    max-height: 3.3em;
+    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
+    text-align: center;
+    /*white-space: nowrap;*/
 }
 
 
@@ -130,77 +130,77 @@
 
 
 .v-connection-label-container {
-    max-width:3em;
+    max-width: 3em;
 }
 
 .v-problem-area {
-    display:flex;
-    flex-flow:column nowrap;
-    justify-content:center;
-    align-items:stretch;
-    flex:2 2 16em;
-    /*min-width:8em;*/
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+    align-items: stretch;
+    flex: 2 2 16em;
+    /*min-width: 8em;*/
 }
 .v-problem-area > div > a {
-    display:none;
+    display: none;
 }
 .v-problem-area:hover > div > a {
-    display:block;
+    display: block;
 }
 
 .v-problem-scroll-container {
-    display:flex;
-    flex-flow:column nowrap;
-    justify-content:center;
-    align-items:stretch;
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+    align-items: stretch;
 
     /* capped height */
-    height:20em;
+    height: 20em;
     /* override with vh if available */
-    /*height:35vh;*/
+    /*height: 35vh;*/
     /* override with vmax if available */
-    /*height:30vmax;*/
+    /*height: 30vmax;*/
 
     /* uncapped height */
-    /*height:auto;*/
+    /*height: auto;*/
 }
 
 .v-problem-scroll {
-    display:flex;
-    flex-flow:column nowrap;
-    justify-content:flex-start;
-    overflow-x:hidden;
-    overflow-y:auto;
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: flex-start;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 .driver-scroll {
-    align-items:flex-end;
-    text-align:right;
+    align-items: flex-end;
+    text-align: right;
 }
 
 .impact-scroll {
-    align-items:flex-start;
-    text-align:left;
+    align-items: flex-start;
+    text-align: left;
 }
 
 .v-arrow-container {
-    height:2em;
+    height: 2em;
 }
 
 /* cannot be flexbox as it breaks scrolling in chrome */
 .v-problem {
-    margin:0.5em 0;
+    margin: 0.5em 0;
 }
-.v-problem:first-child {
+.v-problem: first-child {
     margin-top: 0;
 }
-.v-problem:last-child {
+.v-problem: last-child {
     margin-bottom: 0;
 }
 
 .v-problem-link-container {
-    font-size:1em;
-    line-height:1.1em;
+    font-size: 1em;
+    line-height: 1.1em;
 }
 
 
@@ -209,27 +209,27 @@
 
 
 .problem-link {
-    color:#1A1A1A;
+    color: #1A1A1A;
 }
 
 .problem-icon {
-    color:#1A1A1A;
-    font-size:1.2em;
-    margin:0.15em;
+    color: #1A1A1A;
+    font-size: 1.2em;
+    margin: 0.15em;
 }
 
 .add-problem-icon {
-    color:#1A1A1A;
-    font-size:1.2em;
-    margin:0.3em;
+    color: #1A1A1A;
+    font-size: 1.2em;
+    margin: 0.3em;
 }
 
 .problem-focus-icon {
-    color:#1A1A1A;
-    font-size:4em;
-    margin:0 0.05em -0.025em 0.05em;
-    padding:0 0;
-    /*margin:0.25em;*/
+    color: #1A1A1A;
+    font-size: 4em;
+    margin: 0 0.05em -0.025em 0.05em;
+    padding: 0 0;
+    /*margin: 0.25em;*/
 }
 
 
@@ -237,77 +237,77 @@
 
 
 #center-network-area {
-    display:flex;
-    flex-flow:column nowrap;
-    justify-content:center;
-    align-items:center;
-    flex:6 6 16em;
-    /*min-width:8em;*/
-    /*height:24em;*/
-    text-align:center;
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+    align-items: center;
+    flex: 6 6 16em;
+    /*min-width: 8em;*/
+    /*height: 24em;*/
+    text-align: center;
 }
 
 .problem-focus-container {
-    position:relative;
-    /*margin:0 2em;*/
+    position: relative;
+    /*margin: 0 2em;*/
 }
 
 .problem-focus-label-container {
-    position:absolute;
-    margin:auto;
-    /*padding:0 1%;*/
-    top:0;
-    right:0;
-    bottom:0;
-    left:0;
-    z-index:100;
-    width:80%;
-    /*height:50%;*/
-    max-height:50%;
-    overflow:hidden;
+    position: absolute;
+    margin: auto;
+    /*padding: 0 1%;*/
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 100;
+    width: 80%;
+    /*height: 50%;*/
+    max-height: 50%;
+    overflow: hidden;
 
-    display:flex;
-    flex-flow:column nowrap;
-    justify-content:center;
-    align-items:center;
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+    align-items: center;
 }
 
 .problem-focus-label {
-    line-height:1.1em;
-    color:white;
+    line-height: 1.1em;
+    color: white;
 }
 
 .problem-focus-label:hover {
     text-decoration: underline;
-    color:white;
+    color: white;
 }
 
 .v-connector {
-/*    display:flex;
-    flex-direction:row;
-    justify-content:center;
-    align-items:stretch;
+/*    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: stretch;
 */
-    /*display:table;*/
+    /*display: table;*/
 }
 
 .v-connector-left {
-    /*display:inline-block;*/
-    /*height:16em;*/
+    /*display: inline-block;*/
+    /*height: 16em;*/
 
-    display:table-cell;
-    /*width:1em;*/
-    height:16em;
+    display: table-cell;
+    /*width: 1em;*/
+    height: 16em;
     border-right: 0.2em solid #1A1A1A;
 }
 
 .v-connector-right {
-    /*display:inline-block;*/
-    /*height:16em;*/
+    /*display: inline-block;*/
+    /*height: 16em;*/
 
-    display:table-cell;
-    /*width:1em;*/
-    height:16em;
+    display: table-cell;
+    /*width: 1em;*/
+    height: 16em;
     border-left: 0.2em solid #1A1A1A;
 }
 
@@ -334,59 +334,59 @@
 /* 320px */
 @media (min-width: 20em) {
     .problem-focus-icon {
-        font-size:4em;
+        font-size: 4em;
     }
 }
 
 /* 448px */
 @media (min-width: 28em) {
     .problem-focus-icon {
-        font-size:5em;
+        font-size: 5em;
     }
 }
 
 /* 512px */
 @media (min-width: 32em) {
     .problem-focus-icon {
-        font-size:6em;
+        font-size: 6em;
     }
 }
 
 /* 768px */
 @media (min-width: 48em) {
     .problem-focus-icon {
-        /*display:none;*/
-        font-size:12em
+        /*display: none;*/
+        font-size: 12em
     }
     .problem-focus-label {
-        font-size:1.2em;
+        font-size: 1.2em;
     }
 }
 
 /* 1024px */
 @media (min-width: 64em) {
     .problem-focus-icon {
-        font-size:16em
+        font-size: 16em
     }
     .problem-focus-label {
-        font-size:1.6em;
+        font-size: 1.6em;
     }
 }
 
 /* 1280px */
 @media (min-width: 80em) {
     .problem-focus-icon {
-        font-size:20em
+        font-size: 20em
     }
     .problem-focus-label {
-        font-size:2em;
+        font-size: 2em;
     }
 }
 
 /* 768px */
 @media (max-width: 48em) {
     .problem-focus-label {
-        display:none;
+        display: none;
     }
 }
 
@@ -415,7 +415,7 @@ header, section, .problem-focus-icon .problem-focus-label {
   transform-origin: 80% 79%;
 
   /* Should be unset in IE9+ I think. */
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+  filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=3);
 }
 
 .rotate-impacts {
@@ -433,5 +433,5 @@ header, section, .problem-focus-icon .problem-focus-label {
   transform-origin: 86% 10%;
 
   /* Should be unset in IE9+ I think. */
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+  filter: progid: DXImageTransform.Microsoft.BasicImage(rotation=3);
 }

--- a/intertwine/problems/static/css/network.css
+++ b/intertwine/problems/static/css/network.css
@@ -98,10 +98,10 @@
     resize: none;
     text-align: center;
 }
-.h-problem: first-child {
+.h-problem:first-child {
     margin-left: 0;
 }
-.h-problem: last-child {
+.h-problem:last-child {
     margin-right: 0;
 }
 
@@ -191,10 +191,10 @@
 .v-problem {
     margin: 0.5em 0;
 }
-.v-problem: first-child {
+.v-problem:first-child {
     margin-top: 0;
 }
-.v-problem: last-child {
+.v-problem:last-child {
     margin-bottom: 0;
 }
 

--- a/intertwine/problems/static/css/problems.css
+++ b/intertwine/problems/static/css/problems.css
@@ -1,13 +1,13 @@
 #problem-list-section {
-    margin-top:1em;
-    color:#1A1A1A;
-    vertical-align:top;
-    text-align:left;
+    margin-top: 1em;
+    color: #1A1A1A;
+    vertical-align: top;
+    text-align: left;
 }
 
 .indent {
     font-size: 1em;
-    width:80%;
+    width: 80%;
     margin: 0 auto;
 }
 

--- a/intertwine/problems/templates/problem.html
+++ b/intertwine/problems/templates/problem.html
@@ -10,6 +10,8 @@
       rel="stylesheet" type="text/css">
 <link href="{{ url_for('problems.static', filename='css/network.css') }}"
       rel="stylesheet" type="text/css">
+<!-- <link href="{{ url_for('static', filename='css/network.scss.css') }}"
+      rel="stylesheet" type="text/css">-->
 <!--[if IE]>
   <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 <![endif]-->

--- a/intertwine/problems/views.py
+++ b/intertwine/problems/views.py
@@ -25,9 +25,9 @@ def render_problem(problem_name):
     '''Problem Page'''
     human_id = problem_name.lower()
     problem = Problem.query.filter_by(human_id=human_id).first()
-    # TODO: add geo and org to query strings
-    geo = 'United States/Texas/Austin'
+    # TODO: add org and geo to URL or query string
     org = None
+    geo = 'United States/Texas/Austin'
     connections = problem.connections_with_ratings(geo_scope=geo,
                                                    org_scope=org,
                                                    aggregation='strict',
@@ -47,5 +47,7 @@ def render_problem(problem_name):
         title=problem.name,
         problem=problem,
         connections=connections,
+        org=org,
+        geo=geo
         )
     return template

--- a/intertwine/problems/views.py
+++ b/intertwine/problems/views.py
@@ -4,7 +4,7 @@
 import flask
 from flask import abort, render_template
 
-from . import blueprint
+from . import blueprint, problem_db
 from .models import Problem
 
 
@@ -29,7 +29,9 @@ def render_problem(problem_name):
     geo = 'United States/Texas/Austin'
     org = None
     connections = problem.connections_with_ratings(geo_scope=geo,
-                                                   org_scope=org)
+                                                   org_scope=org,
+                                                   aggregation='strict',
+                                                   session=problem_db.session)
     if problem is None:
         # TODO: Instead of aborting, reroute to problem_not_found page
         # Oops! 'X' is not a problem found in Intertwine.

--- a/intertwine/problems/views.py
+++ b/intertwine/problems/views.py
@@ -28,8 +28,8 @@ def render_problem(problem_name):
     # TODO: add org and geo to URL or query string
     org = None
     geo = 'United States/Texas/Austin'
-    connections = problem.connections_with_ratings(geo_scope=geo,
-                                                   org_scope=org,
+    connections = problem.connections_with_ratings(org_scope=org,
+                                                   geo_scope=geo,
                                                    aggregation='strict',
                                                    session=problem_db.session)
     if problem is None:


### PR DESCRIPTION
Implement aggregate rating caching
- for ‘strict’ aggregation, let org=None and geo=None not apply filters
- update aggregates during setting of rating
- add new JSON data for Substance Abuse 

Also: fix Trackable so create_key and init of Trackable classes need not match
