### PR TITLE
Refactor add_broader_problem to use add_rated_connection

### DIFF
--- a/intertwine/communities/static/js/source/network.js
+++ b/intertwine/communities/static/js/source/network.js
@@ -3,19 +3,26 @@ $(document).ready(function() {
     var payload = JSON.parse($('#payload').val());
     var rootKey = payload['root_key'];
     var community = payload[rootKey];
-    var problemKey = community['problem']
+    var problemKey = community['problem'];
     var problem = problemKey ? payload[problemKey]: null;
-    var orgKey = community['org']
+    var orgKey = community['org'];
     var org = orgKey ? payload[orgKey]: null;
-    var geoKey = community['geo']
+    var geoKey = community['geo'];
     var geo = geoKey ? payload[geoKey]: null;
 
+    var isAddingBroaderProblem = false;
+
     $('#add-broader-problem').on('click', function() {
-        $('#broader-scroll').prepend(
-            '<div class="h-problem broader-problem">\n' +
+        if (isAddingBroaderProblem) {
+            return;
+        }
+        isAddingBroaderProblem = true;
+
+        $('#broader-scroll').prepend(  // TODO: move to AddBroaderProblem component
+            '<div id="add-broader-problem-component" class="h-problem broader-problem">\n' +
                 '<div class="h-problem-link-container word-break">\n' +
                     '<form id="add-broader-problem-form" action="add-broader-problem" method="post">\n' +
-                        '<input id="add-broader-problem-name" type="text" name="add-broader-problem-name" maxlength="60" placeholder="Broader Problem"><br>\n' +
+                        '<input id="add-broader-problem-name" type="text" name="add-broader-problem-name" maxlength="60" placeholder="Broader Problem" autofocus><br>\n' +
                         '<a href=# id="submit-add-broader-problem" class="submit-add-adjacent-problem-link"> Add </a>\n' +
                         '<a href=# id="cancel-add-broader-problem" class="cancel-add-adjacent-problem-link"> Cancel </a>\n' +
                     '</form>\n' +
@@ -24,30 +31,64 @@ $(document).ready(function() {
             '</div>'
         );
 
+        function renderNewBroaderConnection(ratedConnectionPayload) {
+            console.log(ratedConnectionPayload);
+            var rootKey = ratedConnectionPayload.root_key;
+            var ratedConnection = ratedConnectionPayload[rootKey];
+
+            $('#broader-scroll').append(
+                '<div class="h-problem broader-problem">' +
+                    '<div class="h-problem-link-container word-break">' +
+                        '<a href="' + ratedConnection.adjacent_community_uri + '" class="problem-link">' +
+                            ratedConnection.adjacent_problem_name +
+                            ' (' + ratedConnection.rating + ')' +
+                        '</a>' +
+                    '</div>' +
+                    '<a href="' + ratedConnection.adjacent_community_uri + '">' +
+                        '<i class="fa fa-circle problem-icon broader-icon"></i>' +
+                    '</a>' +
+                '</div>'
+            );
+        }
+
         $('#submit-add-broader-problem').on('click', function() {
             var problemA = $('#add-broader-problem-name').val();
-            var problemB = problem['name']
 
             var addBroaderProblemPayload = {
-                "axis": "scoped",
-                "problem_a_name": problemA,
-                "problem_b_name": problem['name'],
+                "connection": {
+                    "axis": "scoped",
+                    "problem_a": problemA,
+                    "problem_b": problem['name']
+                },
                 "community": {
-                    "problem_human_id": problem['human_id'],
-                    "org_human_id": null,
-                    "geo_human_id": geo['human_id']
-                }
+                    "problem": problem['human_id'],
+                    "org": null,
+                    "geo": geo['human_id']
+                },
+                "aggregation": "strict",
+                "rating": -1,
+                "weight": 0
             };
             console.log(addBroaderProblemPayload);
 
             $.ajax({
                 type: "POST",
-                url: "http://localhost:5000/problems/connections",
+                url: "http://localhost:5000/problems/rated_connections",
                 data: JSON.stringify(addBroaderProblemPayload),
-                success: function(){},
                 dataType: "json",
-                contentType : "application/json"
+                contentType : "application/json",
+                success: function(ratedConnectionPayload){
+                    renderNewBroaderConnection(ratedConnectionPayload);
+                } // Add new connection and feedback message
             });
+
+            $('#add-broader-problem-component').remove()
+            isAddingBroaderProblem = false;
+        });
+
+        $('#cancel-add-broader-problem').on('click', function() {
+            $('#add-broader-problem-component').remove()
+            isAddingBroaderProblem = false;
         });
     });
 });

--- a/intertwine/utils/tools.py
+++ b/intertwine/utils/tools.py
@@ -10,6 +10,9 @@ from functools import partial
 from inspect import getargspec, getargvalues, stack
 from itertools import chain
 from mock import create_autospec
+from numbers import Real
+
+from past.builtins import basestring
 
 if sys.version.startswith('3'):
     izip = zip
@@ -228,5 +231,7 @@ def vardygrify(cls, **kwds):
             # properties must be set on the type to be used on an instance
             if isinstance(attribute, property):
                 setattr(type(vardygr), attr_name, property(attribute.fget))
+            elif isinstance(attribute, (basestring, Real, tuple, list)):
+                setattr(vardygr, attr_name, attribute)
 
     return vardygr

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -72,6 +72,7 @@ def test_licenses(**options):
         'graphitesend',      # Apache
 
         # Unknown - where did they come from?
+        'aniso8601',         # Nonstandard/permissive: https://goo.gl/0kTVx3
         'gnureadline',       # GPL 2    - TODO: Alternatives?
         'ptyprocess',        # ISC
 


### PR DESCRIPTION
- Limit add_broader_problem to single form
- Remove form on cancel
- Render new rated connection at end on success
- Allow ProblemConnection constructor to also accept problem names
- Simplify connection view logic
- Enable primitive class attribute support in vardygrify (e.g. ROOT_KEY)
- Add aniso8601 to license list - acceptable, but where did it come from?