### PR TITLE
Align FlexTime API with Pendulum and datetime:

### DIFF
--- a/intertwine/content/models.py
+++ b/intertwine/content/models.py
@@ -141,8 +141,8 @@ class Content(AutoTimestampMixin, BaseContentModel):
     def published_timestamp(self):
         flex_dt = FlexTime.instance(self._published_timestamp)
         localized = flex_dt.astimezone(self.tzinfo_published)
-        return FlexTime.instance(localized, self.granularity_published,
-                                 truncate=True)
+        return FlexTime.instance(
+            localized, granularity=self.granularity_published, truncate=True)
 
     @published_timestamp.setter
     def published_timestamp(self, val):

--- a/tests/utils/test_flex_time.py
+++ b/tests/utils/test_flex_time.py
@@ -25,13 +25,41 @@ dst_datetime_tuples = [
 
 @pytest.mark.unit
 @pytest.mark.parametrize('granularity', reversed(FlexTime.Granularity))
+@pytest.mark.parametrize('tzinfo', (None, UTC, 'US/Central'))
+def test_flex_time_now(
+        session, tzinfo, granularity):
+    '''Test now and utcnow for FlexTime class'''
+    gval = granularity.value
+    if granularity is FlexTime.MAX_GRANULARITY:
+        base_now_before = DatetimeClass.now(tz=tzinfo)
+        flex_now = FlexTime.now(tz=tzinfo, granularity=gval)
+        base_now_after = DatetimeClass.now(tz=tzinfo)
+        assert base_now_before < flex_now < base_now_after
+
+        base_tz_name = FlexTime.tzinfo_name_cast(base_now_before.tzinfo)
+        flex_tz_name = FlexTime.tzinfo_name_cast(flex_now.tzinfo)
+        assert flex_tz_name == base_tz_name
+    else:
+        success_count = 0
+        for i in range(2):
+            base_now = DatetimeClass.now(tz=tzinfo)
+            flex_now = FlexTime.now(tz=tzinfo, granularity=gval)
+            # If they span a second change, next time they will not
+            if FlexTime.cast(base_now, granularity=gval) == flex_now:
+                success_count += 1
+
+        assert success_count > 0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('granularity', reversed(FlexTime.Granularity))
 @pytest.mark.parametrize(
     ('year', 'month', 'day', 'hour', 'minute', 'second', 'microsecond',
         'tzinfo', 'fold'), non_dst_datetime_tuples)
 def test_flex_time_instantiation(
         session, year, month, day, hour, minute, second, microsecond, tzinfo,
-        granularity, fold):
-    '''Test core interactions for FlexTime class'''
+        fold, granularity):
+    '''Test core instantiation methods for FlexTime class'''
     full_dt_info = DatetimeInfo(
         year, month, day, hour, minute, second, microsecond, tzinfo, fold)
     gval = granularity.value
@@ -57,6 +85,19 @@ def test_flex_time_instantiation(
         native_dt_via_args = datetime(fold=fold, *dt_native_args)
     assert native_dt == native_dt_via_args
 
+    dt_naive_kwargs = dt_info_native._asdict()
+    if sys.version_info < (3, 6):
+        del dt_naive_kwargs[FlexTime.FOLD_TAG]
+    del dt_naive_kwargs[FlexTime.TZINFO_TAG]
+    naive_dt = datetime(**dt_naive_kwargs)
+
+    dt_naive_args = dt_info_native[:FlexTime.TZINFO_IDX]
+    if sys.version_info < (3, 6):
+        naive_dt_via_args = datetime(*dt_naive_args)
+    else:
+        naive_dt_via_args = datetime(fold=fold, *dt_naive_args)
+    assert naive_dt == naive_dt_via_args
+
     base_dt = DatetimeClass(**dt_info_with_defaults._asdict())
     base_dt_via_args = DatetimeClass(*dt_info_with_defaults)
     assert base_dt == base_dt_via_args
@@ -68,17 +109,21 @@ def test_flex_time_instantiation(
     assert flex_dt == base_dt
     assert flex_dt == native_dt  # True only if not in DST
 
-    for dt in (dt_info, dt_tuple, native_dt, base_dt, flex_dt, flex_dt.info):
+    for dt in (dt_info, dt_tuple, native_dt, naive_dt, base_dt, flex_dt,
+               flex_dt.info):
+
+        tz = dt_info.tzinfo if dt is naive_dt else None
 
         dt_info_null_backfill = FlexTime.form_info(
-            dt, granularity=granularity, truncate=True, default=False)
+            dt, tz=tz, granularity=granularity, truncate=True, default=False)
         assert dt_info_null_backfill == dt_info
 
         dt_info_default_backfill = FlexTime.form_info(
-            dt, granularity=granularity, truncate=True, default=True)
+            dt, tz=tz, granularity=granularity, truncate=True, default=True)
         assert dt_info_default_backfill == dt_info_with_defaults
 
-        flex_dt_via_instance = FlexTime.instance(dt, granularity=granularity)
+        flex_dt_via_instance = FlexTime.instance(dt, tz=tz,
+                                                 granularity=granularity)
         assert flex_dt_via_instance == flex_dt
         assert flex_dt_via_instance is not flex_dt
         assert flex_dt_via_instance.info == dt_info  # True only if not in DST
@@ -91,7 +136,7 @@ def test_flex_time_instantiation(
         'tzinfo', 'fold'), non_dst_datetime_tuples)
 def test_core_flex_time_interactions(
         session, year, month, day, hour, minute, second, microsecond, tzinfo,
-        granularity, fold):
+        fold, granularity):
     '''Test core interactions for FlexTime class'''
     full_dt_info = DatetimeInfo(
         year, month, day, hour, minute, second, microsecond, tzinfo, fold)
@@ -139,8 +184,8 @@ def test_core_flex_time_interactions(
         'tzinfo', 'fold'), dst_datetime_tuples)
 def test_flex_time_zone_changes(
         session, year, month, day, hour, minute, second, microsecond, tzinfo,
-        granularity, fold):
-    '''Test core interactions for FlexTime class'''
+        fold, granularity):
+    '''Test time zone changes for FlexTime class'''
     full_dt_info = DatetimeInfo(
         year, month, day, hour, minute, second, microsecond, tzinfo, fold)
     gval = granularity.value


### PR DESCRIPTION
- Add now() to accept tz (default local) and granularity
- Add utcnow() to accept granularity (default max)
- Add tz (default UTC) to instance(), cast(), form_info()
- Add default (tz) to extract_tzinfo(), tzinfo_cast(),
  tzinfo_instance_cast(), and tzinfo_name_cast()
- Make Granularity enum values upper case
- Update Content given FlexTime API changes