### PR TITLE
Add Trackable.reconstruct(components):

### DIFF
--- a/intertwine/__init__.py
+++ b/intertwine/__init__.py
@@ -12,9 +12,6 @@ from flask_bootstrap import Bootstrap
 from .bases import BaseIntertwineMeta, BaseIntertwineModel
 from .__metadata__ import *  # noqa
 
-# from . import demo
-# from sassutils.wsgi import SassMiddleware
-
 
 # Set up base model and database connection, and attach query property
 IntertwineModel = make_declarative_base(Base=BaseIntertwineModel,
@@ -24,6 +21,8 @@ intertwine_db = Manager(Model=IntertwineModel)
 extend_declarative_base(IntertwineModel, session=intertwine_db.session)
 
 from . import auth, communities, content, geos, main, problems, signup  # noqa
+
+IntertwineModel.initialize_table_model_map()
 
 
 def create_app(name=None, config=None):
@@ -35,6 +34,7 @@ def create_app(name=None, config=None):
     Returns:
         Flask: a Flask app
 
+    Usage:
     >>> from intertwine import create_app
     >>> from config import DevConfig
     >>> app = create_app(config=DevConfig)
@@ -51,11 +51,6 @@ def create_app(name=None, config=None):
     #     from flask_debugtoolbar import DebugToolbarExtension
     #     toolbar = DebugToolbarExtension()
 
-    # Auto-build SASS/SCSS for each request
-    # app.wsgi_app = SassMiddleware(app.wsgi_app, {
-    #     __name__: ('static/sass', 'static/css', 'static/css')
-    # })
-
     # TODO: replace with Bootstrap 4
     Bootstrap(app)
 
@@ -69,12 +64,6 @@ def create_app(name=None, config=None):
     app.register_blueprint(content.blueprint, url_prefix='/content')
 
     # app.url_map.strict_slashes = False
-    # app.register_blueprint(demo.blueprint, url_prefix='/demo')
-
-    # Auto-build SASS/SCSS for each request
-    # app.wsgi_app = SassMiddleware(app.wsgi_app, {
-    #     __name__: ('problems/static/sass', 'problems/static/css', 'problems/static/css')
-    # })
 
     # if app.config['DEBUG']:
     #     toolbar.init_app(app)

--- a/intertwine/bases.py
+++ b/intertwine/bases.py
@@ -8,6 +8,7 @@ from alchy.model import ModelBase
 
 from intertwine.initiation import InitiationMixin, InitiationMetaMixin
 from intertwine.trackable import Trackable
+from intertwine.trackable.utils import build_table_model_map
 from intertwine.utils.enums import UriType
 from intertwine.utils.jsonable import Jsonable
 from intertwine.utils.mixins import AutoTableMixin
@@ -124,3 +125,8 @@ class BaseIntertwineModel(InitiationMixin, Jsonable, AutoTableMixin,
                 pass
 
         raise KeyError('Unable to create JSON key')
+
+    @classmethod
+    def initialize_table_model_map(cls):
+        '''Initialize table model map; invoke after loading all models'''
+        cls._table_model_map = build_table_model_map(cls)

--- a/intertwine/communities/models.py
+++ b/intertwine/communities/models.py
@@ -8,16 +8,15 @@ from itertools import groupby
 from operator import attrgetter
 
 from sqlalchemy import Column, ForeignKey, Index, desc, orm, types
-from sqlalchemy.orm.exc import NoResultFound
 
 from intertwine import IntertwineModel
-from intertwine.geos.models import Geo
 from intertwine.problems.exceptions import InvalidAggregation
 from intertwine.problems.models import (
     AggregateProblemConnectionRating as APCR,
     ProblemConnection as PC,
     ProblemConnectionRating as PCR,
     Problem)
+from intertwine.trackable.exceptions import KeyMissingFromRegistryAndDatabase
 from intertwine.utils.jsonable import Jsonable, JsonProperty
 from intertwine.utils.structures import PeekableIterator
 from intertwine.utils.tools import vardygrify
@@ -151,7 +150,7 @@ class Community(BaseCommunityModel):
                             'problem_id'),
                       )
 
-    Key = namedtuple('CommunityKey', 'problem, org, geo')
+    Key = namedtuple('Community_Key', 'problem, org, geo')
 
     @classmethod
     def create_key(cls, problem, org, geo, **kwds):
@@ -174,23 +173,14 @@ class Community(BaseCommunityModel):
         return self.__class__.Key(self.problem, self.org, self.geo)
 
     @classmethod
-    def get_community(cls, problem_huid, org_huid, geo_huid,
-                      raise_on_miss=False):
-        problem_huid = Problem.convert_name_to_human_id(problem_huid)
-        geo_huid = geo_huid.lower()
-
+    def manifest(cls, problem_huid, org_huid, geo_huid):
+        '''Manifest community, either real or vardygr'''
+        key = cls.reconstruct((problem_huid, org_huid, geo_huid), as_key=True)
         try:
-            return (cls.query.join(Community.problem)
-                             .join(Community.geo)
-                             .filter(Problem.human_id == problem_huid)
-                             .filter(Geo.human_id == geo_huid).one())
+            return cls[key]
 
-        except NoResultFound:
-            problem = Problem.get_problem(problem_huid, raise_on_miss)
-            org = org_huid
-            geo = Geo.get_geo(geo_huid, raise_on_miss)
-            return vardygrify(Community, problem=problem, org=org, geo=geo,
-                              num_followers=0)
+        except KeyMissingFromRegistryAndDatabase:
+            return vardygrify(cls, num_followers=0, **key._asdict())
 
     def __init__(self, problem=None, org=None, geo=None, num_followers=0):
         '''Initialize a new community'''
@@ -289,7 +279,7 @@ class Community(BaseCommunityModel):
         '''Prepare connection rating JSON
 
         Takes a problem, category (e.g. 'drivers'), and an aggregate
-        rating iterable as input and yields the next aggregate rating
+        ratings iterable as input and yields the next aggregate rating
         JSON, where the order follows that of the input iterable and is
         followed by unrated connections sequenced alphabetically.
         '''

--- a/intertwine/content/models.py
+++ b/intertwine/content/models.py
@@ -53,7 +53,7 @@ class Content(AutoTimestampMixin, BaseContentModel):
                             '_published_timestamp',
                             unique=True),)
 
-    Key = namedtuple('ContentKey',  # add publisher?
+    Key = namedtuple('Content_Key',  # add publisher?
                      'title, author_names, publication, published_timestamp')
 
     @classmethod

--- a/intertwine/content/views.py
+++ b/intertwine/content/views.py
@@ -15,7 +15,8 @@ from ..exceptions import InterfaceException
 
 @blueprint.errorhandler(InterfaceException)
 def handle_interface_exception(error):
-    '''Handle invalid usage
+    '''
+    Handle Interface Exception
 
     Intercepts the error and returns a response consisting of the status
     code and a JSON representation of the error.

--- a/intertwine/exceptions.py
+++ b/intertwine/exceptions.py
@@ -12,6 +12,7 @@ class IntertwineException(Exception):
         template = message if message else ' '.join(self.__doc__.split())
         message = template.format(**kwds) if kwds else (
             template.format(*args) if args else template)
+        message = message.strip('\"\'')
         log.error(message)
         # TODO: Change to super() once on Python 3.6
         Exception.__init__(self, message)

--- a/intertwine/problems/exceptions.py
+++ b/intertwine/problems/exceptions.py
@@ -26,8 +26,7 @@ class InvalidEntity(IntertwineException):
 
 
 class InvalidConnectionAxis(IntertwineException):
-    '''Connection axis '{axis}' is not valid. Must be 'causal' or
-    'scoped'.'''
+    '''Invalid axis: {axis}. Valid axes: {valid_axes}'''
 
 
 class CircularConnection(IntertwineException):
@@ -59,10 +58,6 @@ class InvalidUser(IntertwineException):
 
 class InvalidProblemForConnection(IntertwineException):
     '''{problem!r} must be a problem in {connection!r}.'''
-
-
-class InvalidAxis(IntertwineException):
-    '''Invalid axis: {invalid_axis}. Valid axes: {valid_axes}'''
 
 
 class InvalidProblemName(IntertwineException):

--- a/intertwine/problems/views.py
+++ b/intertwine/problems/views.py
@@ -17,7 +17,8 @@ from intertwine.utils.tools import vardygrify
 
 @blueprint.errorhandler(InterfaceException)
 def handle_interface_exception(error):
-    '''Handle invalid usage
+    '''
+    Handle Interface Exception
 
     Intercept the error and return a response consisting of the status
     code and a JSON representation of the error.
@@ -58,8 +59,8 @@ def get_problem_json(problem_huid):
     json_kwargs = dict(Problem.objectify_json_kwargs(request.args))
 
     try:
-        problem = Problem.get_problem(problem_huid, raise_on_miss=True)
-    except IntertwineException as e:
+        problem = Problem.reconstruct(problem_huid)
+    except KeyError as e:
         raise ResourceDoesNotExist(str(e))
 
     return jsonify(problem.jsonify(**json_kwargs))
@@ -75,9 +76,11 @@ def get_problem_html(problem_huid):
     curl -H 'accept:text/html' -X GET \
     'http://localhost:5000/problems/homelessness'
     '''
-    problem = Problem.get_problem(problem_huid)
+    problem_huid = Problem.convert_name_to_human_id(problem_huid)
 
-    if problem is None:
+    try:
+        problem = Problem.reconstruct(problem_huid)
+    except KeyError:
         # TODO: Instead of aborting, reroute to problem_not_found page
         # Oops! 'X' is not a problem found in Intertwine.
         # Did you mean:
@@ -115,8 +118,8 @@ def get_problem_connection_json(axis, problem_a_huid, problem_b_huid):
     json_kwargs = dict(ProblemConnection.objectify_json_kwargs(request.args))
 
     try:
-        connection = ProblemConnection.get_problem_connection(
-            axis, problem_a_huid, problem_b_huid, raise_on_miss=True)
+        connection = ProblemConnection.reconstruct(
+            (axis, problem_a_huid, problem_b_huid))
     except IntertwineException as e:
         raise ResourceDoesNotExist(str(e))
 

--- a/intertwine/trackable/utils.py
+++ b/intertwine/trackable/utils.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import inspect
+import sys
+from itertools import islice
+
+from past.builtins import basestring
+
+# Python version compatibilities
+if sys.version_info < (3,):
+    lzip = zip  # legacy zip returning list of tuples
+    from itertools import izip as zip
+
+
+SELF_REFERENTIAL_PARAMS = {'self', 'cls', 'meta'}
+
+
+def build_table_model_map(base):
+    '''Build table model map given SQLAlchemy declarative base'''
+    return {model.__table__.fullname: model
+            for model in base._decl_class_registry.values()
+            if hasattr(model, '__table__')}
+
+
+def isiterator(obj):
+    '''Determine if an object is an iterator (not just iterable)'''
+    return hasattr(obj, '__iter__') and not hasattr(obj, '__len__')
+
+
+def isnamedtuple(obj):
+    '''Determine if an object is a namedtuple'''
+    return isinstance(obj, tuple) and hasattr(obj, '_asdict')
+
+
+def isnonstringsequence(obj):
+    '''Determine if an object is a non-string sequence, i.e. list, tuple'''
+    return (hasattr(obj, '__iter__') and hasattr(obj, '__getitem__') and
+            not isinstance(obj, basestring))
+
+
+def merge_args(func, *args, **kwds):
+    '''Merge args into kwds, with keys based on func parameter order'''
+    if not args:
+        return kwds
+
+    try:  # py3
+        func_args = inspect.getfullargspec(func).args
+    except AttributeError:  # py2
+        func_args = inspect.getargspec(func).args
+
+    start = 1 if func_args[0] in SELF_REFERENTIAL_PARAMS else 0
+    arg_names = islice(func_args, start, len(func_args))
+
+    for arg_name, arg_value in zip(arg_names, args):
+        if arg_name in kwds:
+            raise TypeError('Keyword arg {kwd_name} conflicts with '
+                            'positional arg'.format(kwd_name=arg_name))
+        kwds[arg_name] = arg_value
+
+    return kwds

--- a/intertwine/utils/tools.py
+++ b/intertwine/utils/tools.py
@@ -217,9 +217,25 @@ def gethalffullargspec(func):
             kwonlyargs=None, kwonlydefaults=None, annotations=None, *argspec)
 
 
-def isiterator(iterable):
-    '''Determine if an iterable (or any object) is an iterator'''
-    return hasattr(iterable, '__iter__') and not hasattr(iterable, '__len__')
+def iscollection(obj):
+    '''Determine if an object is a collection, e.g. list, tuple, dict, set'''
+    return hasattr(obj, '__iter__') and hasattr(obj, '__len__')
+
+
+def isiterator(obj):
+    '''Determine if an object is an iterator (not just iterable)'''
+    return hasattr(obj, '__iter__') and not hasattr(obj, '__len__')
+
+
+def isnamedtuple(obj):
+    '''Determine if an object is a namedtuple'''
+    return isinstance(obj, tuple) and hasattr(obj, '_asdict')
+
+
+def isnonstringsequence(obj):
+    '''Determine if an object is a non-string sequence, e.g. list, tuple'''
+    return (hasattr(obj, '__iter__') and hasattr(obj, '__getitem__') and
+            not isinstance(obj, basestring))
 
 
 def iterator(*elements):

--- a/tests/problems/test_problem_decode.py
+++ b/tests/problems/test_problem_decode.py
@@ -201,8 +201,7 @@ def test_incremental_decode(session):
 def test_decode_same_data(session):
     '''Tests decoding incrementally'''
     from intertwine.trackable import Trackable
-    from intertwine.problems.models import (Problem, ProblemConnection,
-                                            ProblemConnectionRating)
+    from intertwine.problems.models import Problem
     from data.data_process import decode
 
     create_geo_data(session)


### PR DESCRIPTION
- Add retrieve parameter to instantiate hyper_key via single query
- Add retrieve() to instantiate hyper_key via single query
- Add reconstitute() to instantiate hyper_key incrementally
- Delimit all class-scoped namedtuple names via '_'
- Add isnamedtuple() util

Add Trackable.related_model(field):
- Add Trackable.get_table_model()
- Add initialize_table_model_map to base and invoke at startup
- Add build_table_model_map to trackable.utils
- Add isiterator to trackable.utils
- Replace cls.merge_args() with generic version in trackable.utils
- Fix tget for ProblemConnection even with problem_a/b properties

Update ProblemConnection to support generic key usages:
- Add problems/problem_a/problem_b properties
- Add Problems and Causal/Scoped Key namedtuples
- Refactor create_key/derive_key to use new Key tuples
- Fix trepr to use derived key tuple name
- Fix related problem/uri methods on rated connections

Normalize create_key methods:
- Update Geo.create_key() to accept human_id as first parameter
- Simplify ProblemConnectionRating.create_key
- Fix problem data load based on rating create_key change

Update views to use reconstruct:
- Fix JSON responses for errors via handle_interface_exception
- Add manifest() to Community to support vardygr
- Remove extra quotes from error messages
- Remove all model get methods