### PR TITLE
Clean up legacy Python 2 code

### DIFF
--- a/config/Database.py
+++ b/config/Database.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
 
 
-class DefaultDatabaseConfig(object):
+class DefaultDatabaseConfig:
     """Default config for database"""
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or 'sqlite://'
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/config/Default.py
+++ b/config/Default.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from uuid import uuid4
 
 
-class DefaultConfig(object):
+class DefaultConfig:
     """Base class for all configurations"""
 
     DEBUG = False

--- a/config/Environment.py
+++ b/config/Environment.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 
-class EnvironmentConfig(object):
+class EnvironmentConfig:
     """Base class for environments"""
     ERROR_404_HELP = True  # Flask-Restful setting
 

--- a/config/Mail.py
+++ b/config/Mail.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 
-class DefaultDatabaseConfig(object):
+class DefaultDatabaseConfig:
     MAIL_SERVER = 'smtp.example.com'
     MAIL_PORT = 465
     MAIL_USE_SSL = True

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from .Default import DefaultConfig, DevelopmentConfig, TestingConfig, ProductionConfig, DeployableConfig
+from .Default import (
+    DefaultConfig, DevelopmentConfig, TestingConfig, ProductionConfig, DeployableConfig)
 from .Environment import LocalConfig, HerokuConfig, VagrantConfig, EBConfig, EC2Config
 from .Database import InMemoryConfig, SqlLiteConfig, PostgresConfig, GeoSqlLiteConfig
 
@@ -15,8 +15,7 @@ class LocalDemoConfig(DeployableConfig, LocalConfig, SqlLiteConfig):
     """Configures for local demo"""
 
 
-class DevConfig(DevelopmentConfig, LocalConfig, SqlLiteConfig,
-                GeoSqlLiteConfig):
+class DevConfig(DevelopmentConfig, LocalConfig, SqlLiteConfig, GeoSqlLiteConfig):
     """Standard development environment configuration"""
 
 

--- a/data/data_process.py
+++ b/data/data_process.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Decodes data
 
@@ -10,8 +10,6 @@ Options:
     -v --verbose    More information
     -q --quiet      Less information
 """
-from __future__ import print_function
-
 import io
 import json
 import logging
@@ -35,7 +33,7 @@ from intertwine.problems.models import BaseProblemModel, Problem
 from intertwine.problems.exceptions import InvalidJSONPath
 
 
-class DataSessionManager(object):
+class DataSessionManager:
     """
     Base class for managing data sessions
 

--- a/data/geos/geo_data_process.py
+++ b/data/geos/geo_data_process.py
@@ -1,9 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Loads geo data into Intertwine"""
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
+"""Load geo data into Intertwine"""
 from collections import Counter, defaultdict, namedtuple
 
 from sqlalchemy import desc
@@ -317,7 +314,7 @@ def load_state_counties(geo_session, session, sub1keys=None):
                 state=state.abbrev, name=state.name))
             prior_stusps = stusps
 
-        print(u"\t{name}, {state} ({standard}, '{code}')"
+        print("\t{name}, {state} ({standard}, '{code}')"
               .format(name=r.ghrp_name, state=state.abbrev, standard=ANSI,
                       code=r.ghrp_countyns))
 
@@ -426,7 +423,7 @@ def load_territory_counties(geo_session, session, sub1keys=None):
                 state=territory.abbrev, name=territory.name))
             prior_stusps = stusps
 
-        print(u"\t{name}, {state} ({standard}, '{code}')"
+        print("\t{name}, {state} ({standard}, '{code}')"
               .format(name=full_name, state=stusps, standard=ANSI, code=ansi))
 
         name, lsad, affix, _, _ = LSAD.deaffix(full_name, lsad_code)
@@ -451,7 +448,7 @@ def load_territory_counties(geo_session, session, sub1keys=None):
             pass
 
         else:
-            print(u"\t{name}, {state} ({standard}, '{code}')"
+            print("\t{name}, {state} ({standard}, '{code}')"
                   " with same place ANSI exists".format(
                     name=full_name, state=stusps, standard=ANSI, code=ansi))
 
@@ -550,7 +547,7 @@ def load_subdivision3_geos(geo_session, session, sub1keys=None, sub2keys=None):
 
         # Invalid cousub (e.g. 'County subdivisions not defined')
         if cousubns == '00000000':
-            print(u"\t\tSkipping invalid cousub: {name} ({standard}, '{code}')"
+            print("\t\tSkipping invalid cousub: {name} ({standard}, '{code}')"
                   .format(name=r.ghrp_name, standard=ANSI, code=cousubns))
             continue
 
@@ -1569,7 +1566,7 @@ def load_cbsa_geos(geo_session, session, sub1keys=None, cbsa_keys=None):
                 CBSARecord(*records.peek()).cbsa_cbsa_code != cbsa_code):
 
             cbsa_name = r.cbsa_cbsa_name
-            print(u"\t\tCBSA: {name} ({cbsa_2010}, '{code}')"
+            print("\t\tCBSA: {name} ({cbsa_2010}, '{code}')"
                   .format(name=cbsa_name, cbsa_2010=CBSA_2010, code=cbsa_code))
 
             cbsa = Geo(name=cbsa_name + ' Area',
@@ -1663,7 +1660,7 @@ def load_cbsa_geos(geo_session, session, sub1keys=None, cbsa_keys=None):
                         CBSARecord(*records.peek()).cbsa_csa_code != csa_code):
 
                     csa_name = r.cbsa_csa_name
-                    print(u"\t\tCSA: {name} ({csa_2010}, '{code}')"
+                    print("\t\tCSA: {name} ({csa_2010}, '{code}')"
                           .format(name=csa_name, csa_2010=CSA_2010,
                                   code=csa_code))
 

--- a/data/geos/models.py
+++ b/data/geos/models.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import re
 from collections import namedtuple

--- a/data/users/load.py
+++ b/data/users/load.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Loads user data into python

--- a/intertwine/__init__.py
+++ b/intertwine/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 Base platform for intertwine.

--- a/intertwine/__main__.py
+++ b/intertwine/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from flask_script import Manager
 

--- a/intertwine/__metadata__.py
+++ b/intertwine/__metadata__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+from datetime import datetime
+
 
 __all__ = (
     '__project__', '__description__', '__versionstr__', '__author__',
@@ -13,7 +14,7 @@ __all__ = (
 # ----------------------------------------------------------------------
 __project__ = 'intertwine'
 __description__ = "Untangle the world's problems"
-__versionstr__ = '0.3.0-dev'
+__versionstr__ = '0.4.0-dev'
 
 __author__ = 'Intertwine'
 __author_email__ = 'engineering@intertwine.io'
@@ -21,7 +22,7 @@ __author_email__ = 'engineering@intertwine.io'
 __maintainer__ = 'Intertwine'
 __maintainer_email__ = 'engineering@intertwine.io'
 
-__copyright_years__ = '2015-2019'
+__copyright_years__ = f'2015-{datetime.utcnow().year}'
 __license__ = 'Copyright Intertwine'
 __url__ = 'https://github.com/IntertwineIO/platform.git'
 __version__ = tuple([
@@ -40,9 +41,7 @@ __classifiers__ = [
     'License :: Other/Proprietary License',
     'Natural Language :: English',
     'Operating System :: POSIX',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Software Development',

--- a/intertwine/auth/__init__.py
+++ b/intertwine/auth/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from flask import Blueprint
 from flask_login import LoginManager
 from flask_security import Security, SQLAlchemyUserDatastore

--- a/intertwine/auth/decorators.py
+++ b/intertwine/auth/decorators.py
@@ -3,7 +3,7 @@ import functools
 from types import FunctionType, MethodType
 
 
-class login_required(object):
+class login_required:
     """Login decorator controls permissions for a function
 
     The login_required decorator can decorate a function (preferred) or

--- a/intertwine/auth/models.py
+++ b/intertwine/auth/models.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from alchy.model import ModelBase, make_declarative_base
 from flask_security import UserMixin, RoleMixin
 from sqlalchemy import orm, types, Column, ForeignKey, Table

--- a/intertwine/auth/views.py
+++ b/intertwine/auth/views.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import flask
 from flask import render_template
 

--- a/intertwine/bases.py
+++ b/intertwine/bases.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-import sys
 from collections import OrderedDict
 from itertools import chain, groupby
+from urllib.parse import parse_qsl, urlencode, urlparse
 
 from alchy.model import ModelBase
 
@@ -14,13 +12,6 @@ from intertwine.utils.enums import UriType
 from intertwine.utils.jsonable import Jsonable, JsonProperty
 from intertwine.utils.mixins import AutoTableMixin
 from intertwine.utils.tools import get_value
-
-if sys.version_info >= (3,):
-    from urllib.parse import parse_qsl, urlencode, urlparse
-    unicode = str
-else:
-    from urllib import urlencode
-    from urlparse import parse_qsl, urlparse
 
 
 class BaseIntertwineMeta(InitiationMetaMixin, Trackable):
@@ -98,7 +89,7 @@ class BaseIntertwineModel(InitiationMixin, Jsonable, AutoTableMixin,
         except AttributeError:
             path, query = components, None
 
-        path_components = (unicode(component) if component is not None else ''
+        path_components = (str(component) if component is not None else ''
                            for component in path)
 
         sub_blueprint = cls.sub_blueprint_name()

--- a/intertwine/communities/__init__.py
+++ b/intertwine/communities/__init__.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from flask import Blueprint
 from alchy import Manager
 from alchy.model import extend_declarative_base

--- a/intertwine/communities/models.py
+++ b/intertwine/communities/models.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import math
 from collections import namedtuple
 from itertools import groupby

--- a/intertwine/communities/views.py
+++ b/intertwine/communities/views.py
@@ -1,17 +1,12 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import flask
-from flask import (abort, jsonify, make_response, redirect, render_template,
-                   request)
+from flask import abort, jsonify, make_response, redirect, render_template, request
 
 from . import blueprint
 from intertwine.connectors.contextualize.community_content_connector import (
     CommunityContentConnector)
-from intertwine.exceptions import (InterfaceException, IntertwineException,
-                                   ResourceDoesNotExist)
+from intertwine.exceptions import (
+    InterfaceException, IntertwineException, ResourceDoesNotExist)
 from intertwine.geos.models import Geo
 from intertwine.problems.models import Problem, ProblemConnection
 from intertwine.utils.flask_utils import json_requested

--- a/intertwine/connectors/contextualize/community_content_connector.py
+++ b/intertwine/connectors/contextualize/community_content_connector.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import json
 import os

--- a/intertwine/content/__init__.py
+++ b/intertwine/content/__init__.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from flask import Blueprint
 from alchy import Manager
 from alchy.model import extend_declarative_base

--- a/intertwine/content/models.py
+++ b/intertwine/content/models.py
@@ -1,15 +1,10 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from collections import namedtuple
 
 import pendulum
 from sqlalchemy import (Column,
                         # ForeignKey,
                         Index, orm, types)
-# from titlecase import titlecase
 
 from intertwine import IntertwineModel
 from intertwine.utils.enums import UriType
@@ -56,9 +51,8 @@ class Content(AutoTimestampMixin, BaseContentModel):
                      'title, author_names, publication, published_timestamp')
 
     @classmethod
-    def create_key(cls, title, author_names, publication, published_timestamp,
-                   **kwds):
-        """Create Content key"""
+    def create_key(cls, title, author_names, publication, published_timestamp, **kwds):
+        """Create Trackable key"""
         lowered_title = title.lower()
         normalized_authors = cls.normalize_author_names(author_names)
         flex_dt = FlexTime.cast(published_timestamp)
@@ -66,7 +60,7 @@ class Content(AutoTimestampMixin, BaseContentModel):
         return cls.Key(lowered_title, normalized_authors, publication, dt_utc)
 
     def derive_key(self, **kwds):
-        """Derive Content key from instance"""
+        """Derive Trackable key from instance"""
         return self.model_class.Key(
             self.title.lower(), self.author_names, self.publication,
             self.published_timestamp.astimezone(UTC).deflex(native=True))

--- a/intertwine/content/views.py
+++ b/intertwine/content/views.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from flask import (current_app, jsonify, make_response, render_template,
                    # redirect,
                    # request

--- a/intertwine/exceptions.py
+++ b/intertwine/exceptions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import logging
 

--- a/intertwine/geos/__init__.py
+++ b/intertwine/geos/__init__.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from flask import Blueprint
 from alchy import Manager
 from alchy.model import extend_declarative_base

--- a/intertwine/geos/models.py
+++ b/intertwine/geos/models.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-import sys
 from collections import OrderedDict, namedtuple
 from functools import reduce
 
@@ -18,12 +14,6 @@ from intertwine.utils.jsonable import JsonProperty
 from intertwine.utils.space import Area, Coordinate, GeoLocation
 from intertwine.utils.tools import (define_constants_at_module_scope,
                                     find_any_words)
-
-# Python version compatibilities
-if sys.version_info < (3,):
-    lzip = zip  # legacy zip returning list of tuples
-    from itertools import izip as zip
-
 
 BaseGeoModel = IntertwineModel
 
@@ -1114,7 +1104,7 @@ class Geo(BaseGeoModel):
             return cls.Key(human_id)
 
         path = path_parent.human_id + Geo.PATH_DELIMITER if path_parent else ''
-        nametag = u'{abbrev_or_name}{qualifier}'.format(
+        nametag = '{abbrev_or_name}{qualifier}'.format(
             abbrev_or_name=abbrev if abbrev else name,
             qualifier=' ' + qualifier if qualifier else '')
         nametag = (nametag.replace('.', '').replace(', ', '_')
@@ -1222,12 +1212,12 @@ class Geo(BaseGeoModel):
 
             the = ('The ' if geo.uses_the and show_The else (
                    'the ' if geo.uses_the and show_the else ''))
-            abbrev = (u' ({})'.format(geo.abbrev)
+            abbrev = (' ({})'.format(geo.abbrev)
                       if geo.abbrev and show_abbrev else '')
-            qualifier = (u' {}'.format(geo.qualifier)
+            qualifier = (' {}'.format(geo.qualifier)
                          if geo.qualifier and show_qualifier else '')
             if plvl == 0:
-                geostr.append(u'{the}{name}{abbrev}{qualifier}'.format(
+                geostr.append('{the}{name}{abbrev}{qualifier}'.format(
                     the=the, name=geo.name, abbrev=abbrev,
                     qualifier=qualifier))
             else:

--- a/intertwine/geos/views.py
+++ b/intertwine/geos/views.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import flask
-from flask import (abort, jsonify, make_response, redirect, render_template,
-                   request)
+from flask import abort, jsonify, make_response, redirect, render_template, request
 
 from . import blueprint
 from .models import Geo, GeoLevel

--- a/intertwine/initiation.py
+++ b/intertwine/initiation.py
@@ -1,17 +1,14 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 
 
-class InitiationMetaMixin(object):
+class InitiationMetaMixin:
 
     def __init__(cls, name, bases, attr):
         super(InitiationMetaMixin, cls).__init__(name, bases, attr)
         cls._class_init_()
 
 
-class InitiationMixin(object):
+class InitiationMixin:
 
     @classmethod
     def _class_init_(cls):

--- a/intertwine/main/__init__.py
+++ b/intertwine/main/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from flask import Blueprint
 from alchy import Manager
 from alchy.model import extend_declarative_base

--- a/intertwine/main/views.py
+++ b/intertwine/main/views.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from flask import redirect
 

--- a/intertwine/problems/__init__.py
+++ b/intertwine/problems/__init__.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from flask import Blueprint
 from alchy import Manager
 from alchy.model import extend_declarative_base

--- a/intertwine/problems/exceptions.py
+++ b/intertwine/problems/exceptions.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..exceptions import IntertwineException
 
 

--- a/intertwine/problems/models.py
+++ b/intertwine/problems/models.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import re
 from collections import OrderedDict, namedtuple
@@ -6,7 +5,6 @@ from contextlib import suppress
 from numbers import Real
 from operator import attrgetter
 
-from past.builtins import basestring
 from sqlalchemy import Column, ForeignKey, Index, or_, orm, types
 from titlecase import titlecase
 from url_normalize import url_normalize
@@ -14,8 +12,8 @@ from url_normalize import url_normalize
 from intertwine import IntertwineModel
 from intertwine.geos.models import Geo
 from intertwine.trackable.exceptions import KeyMissingFromRegistryAndDatabase
-from intertwine.utils.enums import UriType
 from intertwine.utils.analytics import average
+from intertwine.utils.enums import UriType
 
 from .exceptions import (CircularConnection,
                          InconsistentArguments,
@@ -562,7 +560,7 @@ class ProblemConnectionRating(BaseProblemModel):
             self.connection_category = (connection.BROADER if problem is p_b
                                         else connection.NARROWER)
 
-        if isinstance(problem, basestring):
+        if isinstance(problem, str):
             problem_human_id = problem
             problem = Problem[problem_human_id]
             if not problem:
@@ -573,7 +571,7 @@ class ProblemConnectionRating(BaseProblemModel):
             raise InvalidProblemForConnection(problem=problem,
                                               connection=connection)
 
-        if isinstance(geo, basestring):
+        if isinstance(geo, str):
             geo_human_id = geo
             geo = Geo[geo_human_id]
             if not geo:
@@ -804,7 +802,7 @@ class ProblemConnection(BaseProblemModel):
             if not problem:
                 raise ValueError('Invalid problem or problem name: {p}'
                                  .format(p=problem))
-            if isinstance(problem, basestring):
+            if isinstance(problem, str):
                 problem_name = problem
                 problem_key = Problem.create_key(name=problem_name)
                 try:

--- a/intertwine/problems/views.py
+++ b/intertwine/problems/views.py
@@ -1,16 +1,10 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
-from flask import (abort, current_app, jsonify, make_response, redirect,
-                   render_template, request)
+from flask import abort, current_app, jsonify, make_response, redirect, render_template, request
 
 from . import blueprint
 from .models import Problem, ProblemConnection
 from .models import AggregateProblemConnectionRating as APCR
-from ..exceptions import (InterfaceException, IntertwineException,
-                          ResourceDoesNotExist)
+from intertwine.exceptions import InterfaceException, IntertwineException, ResourceDoesNotExist
 from intertwine.utils.flask_utils import json_requested
 from intertwine.utils.vardygr import vardygrify
 

--- a/intertwine/signup/__init__.py
+++ b/intertwine/signup/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # from alchy import Manager
 from flask import Blueprint
 from flask_sqlalchemy import SQLAlchemy

--- a/intertwine/signup/models.py
+++ b/intertwine/signup/models.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import datetime
 
 from . import signup_db
@@ -18,7 +16,7 @@ class SignUp(signup_db.Model):
     def __init__(self, email, username):
         self.email = email
         self.username = username
-        self.timestamp = datetime.datetime()
+        self.timestamp = datetime.datetime.utcnow()
 
     def __repr__(self):
         cname = self.__class__.__name__

--- a/intertwine/signup/views.py
+++ b/intertwine/signup/views.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import flask
 from flask import render_template
 

--- a/intertwine/trackable/__init__.py
+++ b/intertwine/trackable/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 Trackable metaclass

--- a/intertwine/trackable/exceptions.py
+++ b/intertwine/trackable/exceptions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import logging
 

--- a/intertwine/trackable/trackable.py
+++ b/intertwine/trackable/trackable.py
@@ -1,14 +1,8 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import inspect
-import sys
 from collections import namedtuple, OrderedDict
 
 from alchy.model import ModelMeta
-from past.builtins import basestring
 from sqlalchemy.exc import IntegrityError, InvalidRequestError
 from sqlalchemy.orm import aliased, class_mapper
 from sqlalchemy.orm.attributes import InstrumentedAttribute
@@ -17,11 +11,9 @@ from .exceptions import (
     InvalidRegistryKey, KeyConflictError, KeyInconsistencyError,
     KeyMissingFromRegistry, KeyMissingFromRegistryAndDatabase,
     KeyRegisteredAndNoModify)
-from .utils import (build_table_model_map, dehumpify, get_class, isiterator,
-                    isnamedtuple, isnonstringsequence, merge_args)
-
-# Python version compatibilities
-U_LITERAL = 'u' if sys.version_info < (3,) else ''
+from .utils import (
+    TEXT_TYPES, build_table_model_map, dehumpify, get_class, isiterator,
+    isnamedtuple, isnonstringsequence, merge_args)
 
 
 def trepr(self, named=False, raw=True, tight=False, outclassed=True, _lvl=0):
@@ -66,9 +58,9 @@ def trepr(self, named=False, raw=True, tight=False, outclassed=True, _lvl=0):
     try:
         key = self.derive_key()
     except AttributeError:
-        if isinstance(self, basestring) and not raw:
-            return u"{u}'{s}'".format(u=U_LITERAL, s=self)
-        # repr adds u''s and extra escapes for printing unicode
+        if isinstance(self, TEXT_TYPES) and not raw:
+            return f"'{self}'"
+        # repr adds extra escapes for printing unicode
         return repr(self)
 
     osqb, op, cp, csqb = '[', '(', ')', ']'
@@ -84,7 +76,7 @@ def trepr(self, named=False, raw=True, tight=False, outclassed=True, _lvl=0):
         if not named:
             raise ValueError
         key_name = type(key).__name__.replace('_', '.')
-        treprs = [u'{f}={trepr}'.format(
+        treprs = ['{f}={trepr}'.format(
                   f=f, trepr=trepr(getattr(key, f),
                                    named, raw, tight, outclassed, _lvl + 1))
                   for f in key._fields]
@@ -94,16 +86,16 @@ def trepr(self, named=False, raw=True, tight=False, outclassed=True, _lvl=0):
         treprs = [trepr(v, named, raw, tight, outclassed, _lvl + 1)
                   for v in key]
 
-    all_1_line = (u'{cls}{osqb}{key_name}{op}{treprs}{cp}{csqb}'
+    all_1_line = ('{cls}{osqb}{key_name}{op}{treprs}{cp}{csqb}'
                   .format(cls=cls, osqb=osqb, key_name=key_name, op=op,
-                          treprs=(u',' + sp).join(treprs), cp=cp, csqb=csqb))
+                          treprs=(',' + sp).join(treprs), cp=cp, csqb=csqb))
 
     if len(ind1) + len(all_1_line) < Trackable.MAX_WIDTH or tight:
         return all_1_line
     else:
-        return (u'{cls}{osqb}{key_name}{op}\n{ind2}{treprs}\n{ind1}{cp}{csqb}'
+        return ('{cls}{osqb}{key_name}{op}\n{ind2}{treprs}\n{ind1}{cp}{csqb}'
                 .format(cls=cls, osqb=osqb, key_name=key_name, op=op,
-                        ind2=ind2, treprs=(u',\n' + ind2).join(treprs),
+                        ind2=ind2, treprs=(',\n' + ind2).join(treprs),
                         ind1=ind1, cp=cp, csqb=csqb))
 
 
@@ -557,9 +549,9 @@ class Trackable(ModelMeta):
         hyper_key: Trackable key in which objects are replaced by keys
             Example:
             ProblemConnection_CausalKey(
-                axis=u'causal',
-                driver=Problem_Key(human_id=u'domestic_violence'),
-                impact=Problem_Key(human_id=u'homelessness')
+                axis='causal',
+                driver=Problem_Key(human_id='domestic_violence'),
+                impact=Problem_Key(human_id='homelessness')
             )
         _alias=None: Private parameter containing SQLAlchemy alias for
             each foreign key join; used to distinguish between multiple
@@ -595,9 +587,9 @@ class Trackable(ModelMeta):
         hyper_key: Trackable key in which objects are replaced by keys
             Example:
             ProblemConnection_CausalKey(
-                axis=u'causal',
-                driver=Problem_Key(human_id=u'domestic_violence'),
-                impact=Problem_Key(human_id=u'homelessness')
+                axis='causal',
+                driver=Problem_Key(human_id='domestic_violence'),
+                impact=Problem_Key(human_id='homelessness')
             )
         return: instance matching given query_key
         raise: KeyMissingFromRegistryAndDatabase if no instance is found

--- a/intertwine/trackable/utils.py
+++ b/intertwine/trackable/utils.py
@@ -1,21 +1,9 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import inspect
-import sys
 from itertools import islice
 
-from past.builtins import basestring
-
-# Python version compatibilities
-if sys.version_info < (3,):
-    lzip = zip  # legacy zip returning list of tuples
-    from itertools import izip as zip
-
-
 SELF_REFERENTIAL_PARAMS = {'self', 'cls', 'meta'}
+TEXT_TYPES = (str, bytes)
 
 
 ord_A = ord('A')
@@ -66,7 +54,7 @@ def isnamedtuple(obj):
 
 def isnonstringsequence(obj):
     """Check if object is non-string sequence: list, tuple, range..."""
-    if (isinstance(obj, basestring) or hasattr(obj, 'items') or not hasattr(obj, '__getitem__')):
+    if (isinstance(obj, TEXT_TYPES) or hasattr(obj, 'items') or not hasattr(obj, '__getitem__')):
         return False
     try:
         iter(obj)

--- a/intertwine/utils/__init__.py
+++ b/intertwine/utils/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # from flask import Flask, request
 # from flask_restful import abort

--- a/intertwine/utils/analytics.py
+++ b/intertwine/utils/analytics.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from itertools import zip_longest
 

--- a/intertwine/utils/blueprints.py
+++ b/intertwine/utils/blueprints.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from flask import Blueprint
 
 

--- a/intertwine/utils/debug.py
+++ b/intertwine/utils/debug.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import asyncio
 import inspect

--- a/intertwine/utils/decorators.py
+++ b/intertwine/utils/decorators.py
@@ -1,11 +1,8 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from types import FunctionType
 
 
-class singleton(object):
+class singleton:
     memoized = {}
 
     def __init__(self, *args, **kwds):

--- a/intertwine/utils/duck_typing.py
+++ b/intertwine/utils/duck_typing.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from past.builtins import basestring
+from intertwine.utils.tools import TEXT_TYPES
 
 
 def iscollection(obj):
     """Check if object is a collection: list, tuple, dict, set..."""
-    if isinstance(obj, basestring) or not hasattr(obj, '__len__'):
+    if isinstance(obj, TEXT_TYPES) or not hasattr(obj, '__len__'):
         return False
     try:
         iter(obj)
@@ -36,7 +35,7 @@ def isnamedtuple(obj):
 
 def isnonstringsequence(obj):
     """Check if object is non-string sequence: list, tuple, range..."""
-    if (isinstance(obj, basestring) or hasattr(obj, 'items') or not hasattr(obj, '__getitem__')):
+    if (isinstance(obj, TEXT_TYPES) or hasattr(obj, 'items') or not hasattr(obj, '__getitem__')):
         return False
     try:
         iter(obj)

--- a/intertwine/utils/enums.py
+++ b/intertwine/utils/enums.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from enum import Enum
 
 

--- a/intertwine/utils/features/Feature.py
+++ b/intertwine/utils/features/Feature.py
@@ -4,7 +4,7 @@ import json
 # from ..registry import RegistryObject
 
 
-class Feature(object):
+class Feature:
     """
     Feature flag
 

--- a/intertwine/utils/flask_utils.py
+++ b/intertwine/utils/flask_utils.py
@@ -1,13 +1,10 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from past.builtins import basestring
-
 from datetime import timedelta
 from functools import update_wrapper
 
 from flask import make_response, request, current_app
+
+from intertwine.utils.tools import TEXT_TYPES
 
 
 def crossdomain(origin=None, methods=None, headers=None,
@@ -48,9 +45,9 @@ def crossdomain(origin=None, methods=None, headers=None,
     """
     if methods is not None:
         methods = ', '.join(sorted(x.upper() for x in methods))
-    if headers is not None and not isinstance(headers, basestring):
+    if headers is not None and not isinstance(headers, TEXT_TYPES):
         headers = ', '.join(x.upper() for x in headers)
-    if not isinstance(origin, basestring):
+    if not isinstance(origin, TEXT_TYPES):
         origin = ', '.join(origin)
     if isinstance(max_age, timedelta):
         max_age = max_age.total_seconds()

--- a/intertwine/utils/jsonable.py
+++ b/intertwine/utils/jsonable.py
@@ -1,11 +1,6 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import inspect
 import json
-import sys
 from collections import OrderedDict, namedtuple
 from datetime import datetime
 from enum import Enum, EnumMeta
@@ -13,7 +8,6 @@ from functools import partial
 from itertools import chain, islice
 from math import floor
 from operator import attrgetter, itemgetter
-from past.builtins import basestring
 from typing import Any, Callable, Dict, Set, Text, Union
 
 import sqlalchemy
@@ -24,19 +18,12 @@ from sqlalchemy.orm.relationships import RelationshipProperty as RP
 
 from .duck_typing import isiterable, isiterator
 from .structures import FieldPath, InsertableOrderedDict, PeekableIterator
-from .tools import derive_defaults, derive_arg_types, enumify, get_class, stringify
+from .tools import TEXT_TYPES, derive_defaults, derive_arg_types, enumify, get_class, stringify
 
-# Python version compatibilities
-if sys.version_info < (3,):
-    JSON_NUMBER_TYPES = (bool, float, int, long)  # noqa: ignore=F821
-    lmap = map  # legacy map returning list
-    from itertools import imap as map
-else:
-    JSON_NUMBER_TYPES = (bool, float, int)
-    unicode = str
+JSON_NUMBER_TYPES = (bool, int, float)
 
 
-class JsonProperty(object):
+class JsonProperty:
 
     _count = 0
 
@@ -73,7 +60,7 @@ class JsonProperty(object):
         return f'<JsonProperty {self.index}: {self.name}>'
 
 
-class Jsonable(object):
+class Jsonable:
 
     JSONIFY = 'jsonify'  # Must match the method name
     JSON_ROOT = 'root'
@@ -291,7 +278,7 @@ class Jsonable(object):
             return value
         if isinstance(value, datetime):
             return value.isoformat()
-        return unicode(value)
+        return str(value)
 
     @classmethod
     def jsonify_value(cls, value, kwarg_map=None, _path=None, _json=None, **json_kwargs):
@@ -373,7 +360,7 @@ class Jsonable(object):
                     kwarg_map=kwarg_map, _path=_path, _json=_json, **json_kwargs)
             return item_key or jsonified
 
-        if not isiterable(value) or isinstance(value, basestring) or value_is_class:
+        if not isiterable(value) or isinstance(value, TEXT_TYPES) or value_is_class:
             default = default or cls.ensure_json_safe
             return default(value)
 
@@ -684,8 +671,6 @@ class Jsonable(object):
         return self.__unicode__().encode('utf-8')
 
     def __str__(self):
-        if sys.version_info < (3,):
-            return self.__bytes__()
         return self.__unicode__()
 
     def __unicode__(self):  # py2 only

--- a/intertwine/utils/loggers.py
+++ b/intertwine/utils/loggers.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 import json
 import logging

--- a/intertwine/utils/mixins.py
+++ b/intertwine/utils/mixins.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import pendulum
 from sqlalchemy import Column, orm, types
 from sqlalchemy.ext.declarative import declared_attr
@@ -13,14 +9,14 @@ from .structures import MultiKeyMap
 from .tools import camelCaseTo_snake_case
 
 
-class AutoIdMixin(object):
+class AutoIdMixin:
     """Automatically create primary id key"""
     id = Column(types.Integer, primary_key=True)
     # Ensure id is first field when jsonified
     jsonified_id = JsonProperty(name='id', begin=True)
 
 
-class AutoTablenameMixin(object):
+class AutoTablenameMixin:
     """Autogenerate table name"""
     @declared_attr
     def __tablename__(cls):
@@ -31,7 +27,7 @@ class AutoTableMixin(AutoIdMixin, AutoTablenameMixin):
     """Standardize automatic tables"""
 
 
-class AutoTimestampMixin(object):
+class AutoTimestampMixin:
     """Automatically save timestamps on create and update"""
     tz = pendulum.timezone('UTC')
 
@@ -66,7 +62,7 @@ class AutoTimestampMixin(object):
                                                end=True)
 
 
-class KeyedUp(object):
+class KeyedUp:
     """KeyedUp mixin for caching with multiple distinct field keys"""
 
     # Override with fields to be used by KeyedUp

--- a/intertwine/utils/quantized.py
+++ b/intertwine/utils/quantized.py
@@ -1,20 +1,8 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-import sys
 from decimal import Decimal
 
-# Python version compatibilities
-if sys.version_info < (3,):
-    INT_TYPES = (int, long)  # noqa: ignore=F821
-else:
-    INT_TYPES = (int,)
-    long = int
-    unicode = str
 
-
-class QuantizedDecimal(object):
+class QuantizedDecimal:
     """
     QuantizedDecimal
 
@@ -271,6 +259,3 @@ class QuantizedDecimal(object):
 
     def __int__(self):
         return int(self.value)
-
-    def __long__(self):
-        return long(self.value)

--- a/intertwine/utils/space.py
+++ b/intertwine/utils/space.py
@@ -1,21 +1,11 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-import sys
 from collections import namedtuple
-from past.builtins import basestring
 
 import pendulum
 from timezonefinder import TimezoneFinder
 
 from intertwine.utils.quantized import QuantizedDecimal
-
-# Python version compatibilities
-if sys.version_info < (3,):
-    INT_TYPES = (int, long)  # noqa: ignore=F821
-else:
-    INT_TYPES = (int,)
+from intertwine.utils.tools import TEXT_TYPES
 
 
 class Area(QuantizedDecimal):
@@ -28,7 +18,7 @@ class Coordinate(QuantizedDecimal):
     DEFAULT_PRECISION = 7  # 7: 11 mm; 6: 0.11 m (https://goo.gl/7qq5sR)
 
 
-class GeoLocation(object):
+class GeoLocation:
     """
     GeoLocation
 
@@ -201,14 +191,14 @@ class GeoLocation(object):
     # Container Methods
 
     def __getitem__(self, key):
-        field = self.COORDINATES[key] if isinstance(key, INT_TYPES) else key
-        if isinstance(field, basestring) and field[0] == '_':
+        field = self.COORDINATES[key] if isinstance(key, int) else key
+        if isinstance(field, TEXT_TYPES) and field[0] == '_':
             raise AttributeError('Attempting to access private member')
         return getattr(self, field)
 
     def __setitem__(self, key, value):
-        field = self.COORDINATES[key] if isinstance(key, INT_TYPES) else key
-        if isinstance(field, basestring) and field[0] == '_':
+        field = self.COORDINATES[key] if isinstance(key, int) else key
+        if isinstance(field, TEXT_TYPES) and field[0] == '_':
             raise AttributeError('Attempting to access private member')
         setattr(self, field, value)
 

--- a/intertwine/utils/structures.py
+++ b/intertwine/utils/structures.py
@@ -1,20 +1,10 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
-import sys
 from collections import Counter, OrderedDict, namedtuple
 from contextlib import contextmanager
 from enum import IntEnum
 from operator import eq, attrgetter, itemgetter
 
 from .tools import nth_key
-
-# Python version compatibilities
-if sys.version_info < (3,):
-    lmap = map  # legacy map returning list
-    from itertools import imap as map
 
 
 class Sentinel:
@@ -135,8 +125,8 @@ class InsertableOrderedDict(OrderedDict):
         return self.__class__(self)
 
     def __repr__(self):
-        return u'{cls}({tuples})'.format(cls=self.__class__.__name__,
-                                         tuples=tuple(self.items()))
+        return '{cls}({tuples})'.format(cls=self.__class__.__name__,
+                                        tuples=tuple(self.items()))
 
     def _get(self, key, default=None):
         return self._dict.get(key, default)
@@ -253,7 +243,7 @@ class InsertableOrderedDict(OrderedDict):
         for obj in peekable:
             key, value = keygetter(obj), valgetter(obj)
             if self.get(key, sentinel) is not sentinel:
-                raise KeyError(u"Duplicate key: '{}'".format(key))
+                raise KeyError("Duplicate key: '{}'".format(key))
             next_key = (keygetter(peekable.peek()) if peekable.has_next()
                         else sentinel)
             self._setitem(key, self.ValueTuple(value, next_key, prior_key))

--- a/intertwine/utils/time.py
+++ b/intertwine/utils/time.py
@@ -1,10 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import datetime
-import sys
 from collections import namedtuple
 from enum import Enum
 from itertools import chain, islice
@@ -207,8 +202,6 @@ class FlexTime(DateTime):
         dt_info = self.form_info(self, granularity=self.MAX_GRANULARITY,
                                  default=True, tz_instance=True)
         dt_kwds = dt_info._asdict()
-        if native and sys.version_info < (3, 6):
-            del dt_kwds[self.FOLD_TAG]
         return (datetime.datetime(**dt_kwds) if native
                 else DateTime(**dt_kwds))
 

--- a/intertwine/utils/vardygr.py
+++ b/intertwine/utils/vardygr.py
@@ -1,12 +1,9 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from sqlalchemy.orm.attributes import InstrumentedAttribute, QueryableAttribute
-# from sqlalchemy.orm.instrumentation import ClassManager
-# from sqlalchemy.sql.schema import MetaData
 
 
 class Vardygr(type):
-    u"""
+    """
     Vardygr
 
     A metaclass for uninstrumented imitation of SQLAlchemy models, used
@@ -29,14 +26,14 @@ class Vardygr(type):
 
     About the name:
 
-        Vardoger, also known as vardyvle or vardyger [or vardygr], is a
+        Vardøger, also known as vardyvle or vardyger [or vardygr], is a
         spirit predecessor in Scandinavian folklore. Stories typically
-        include instances that are nearly deja vu in substance, but in
+        include instances that are nearly déjà vu in substance, but in
         reverse, where a spirit with the subject's footsteps, voice,
         scent, or appearance and overall demeanor precedes them in a
         location or activity, resulting in witnesses believing they've
         seen or heard the actual person before the person physically
-        arrives. This bears a subtle difference from a doppelganger,
+        arrives. This bears a subtle difference from a doppelgänger,
         with a less sinister connotation. It has been likened to being a
         phantom double, or form of bilocation.
 

--- a/run-docker
+++ b/run-docker
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Manages the execution of Intertwine's platform app using docker

--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Manages the execution of Intertwine's platform app
@@ -14,8 +14,6 @@ Options:
     -c --config CONFIG  Set config [default: demo] (options: dev, demo, local)
     -r --rebuild        Rebuilds local database
 """
-from __future__ import print_function
-
 import os
 
 from intertwine import create_app

--- a/scripts/check-licenses.py
+++ b/scripts/check-licenses.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 import sys
 
 from pip.utils import get_installed_distributions

--- a/scripts/check_branch.py
+++ b/scripts/check_branch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from git import Repo
 

--- a/scripts/encode-file.py
+++ b/scripts/encode-file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Tests conversion
@@ -11,8 +11,6 @@ Options:
    -d --decoding DECODE    Describes the final file format desired  [default: utf-8]
    -v --verbose            More spam
 """
-from __future__ import print_function
-
 import os
 
 import docopt

--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Platform: Intertwine.io's website
@@ -10,8 +10,6 @@ Copyright (c) 2015-2019
 
 License:  Proprietary.
 """
-from __future__ import unicode_literals
-
 import datetime
 import os
 import re
@@ -294,10 +292,9 @@ def main():
     project_name = metadata['project']
     classifiers = metadata.get('classifiers')
     extras = {k: v for k, v in requirements.items() if k != 'requirements'}
-    year = metadata.get('copyright_years') or datetime.datetime.now().year
+    year = metadata.get('copyright_years') or datetime.datetime.utcnow().year
     lic = metadata.get('license') or 'Copyright {year} - all rights reserved'.format(year=year)
     sass_manifests = get_sass_manifests(metadata)
-    # import pdb; pdb.set_trace()
     links = []
     if sys.platform.startswith('3'):
         links = [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,1 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-

--- a/tests/auth/test_auth_endpoints.py
+++ b/tests/auth/test_auth_endpoints.py
@@ -1,6 +1,8 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import os
 import pytest
+
+from intertwine import create_app
 
 
 @pytest.mark.skip("Auth is currently disabled")
@@ -8,8 +10,6 @@ import pytest
 @pytest.mark.smoke
 def test_auth_admin_(options):
     """Test auth"""
-    from intertwine import create_app
-
     config = options['config']
     app = create_app(config)
     assert 'auth' in app.blueprints
@@ -35,9 +35,6 @@ def test_auth_admin_(options):
 @pytest.mark.smoke
 def test_auth_table_generation(options):
     """Test decoding incrementally"""
-    import os
-    from intertwine import create_app
-
     config = options['config']
     app = create_app(config)
     filepath = app.config['DATABASE'].split('///')[-1]

--- a/tests/auth/test_decorators.py
+++ b/tests/auth/test_decorators.py
@@ -112,7 +112,7 @@ def test_class_decorator(args, kwds, dargs, dkwds, expected, raises):
 
     if not raises:
         @decorator
-        class bar(object):
+        class bar:
 
             def __init__(self, *targs, **tkwds):
                 self.args = targs
@@ -164,7 +164,7 @@ def test_class_method_decorator(args, kwds, dargs, dkwds, expected, raises):
     decorator = get_decorator(*dargs, **dkwds)
 
     if not raises:
-        class bar(object):
+        class bar:
 
             def __init__(self, *targs, **tkwds):
                 self.args = targs

--- a/tests/builders/__init__.py
+++ b/tests/builders/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from .builders import *

--- a/tests/builders/builders.py
+++ b/tests/builders/builders.py
@@ -1,11 +1,8 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 Custom builders for instantiating test data
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import sys
 import uuid
 from collections import OrderedDict

--- a/tests/builders/master.py
+++ b/tests/builders/master.py
@@ -1,11 +1,8 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 Master builder for instantiating test data
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import datetime
 import string
 import sys
@@ -18,17 +15,13 @@ from intertwine import IntertwineModel
 from intertwine.utils.debug import sync_debug
 from intertwine.utils.tools import derive_args
 
-if sys.version_info < (3,):
-    LETTERS = string.letters
-    LOWERCASE = string.lowercase
-else:
-    LETTERS = string.ascii_letters
-    LOWERCASE = string.ascii_lowercase
+LETTERS = string.ascii_letters
+LOWERCASE = string.ascii_lowercase
 
 SQLALCHEMY_MODEL_BASE = IntertwineModel
 
 
-class Builder(object):
+class Builder:
 
     MODEL_BUILDER_TAG = 'Builder'
     BUILDER_FIELD_TAG = 'builder'
@@ -49,6 +42,7 @@ class Builder(object):
     DEFAULT_WORDS = DEFAULT_TEXT.split()
     NOW = pendulum.now()
     SEED = int(NOW.strftime('%Y%m%d'))  # Daily seed: YYYYMMDD
+    # SEED = 20190604
 
     fake = Faker()
     fake.seed(SEED)

--- a/tests/communities/test_community_models.py
+++ b/tests/communities/test_community_models.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import pytest
 
 
@@ -14,7 +10,7 @@ import pytest
     ('Sexual Assault', 'University of Texas', 'Austin', 5000),
     ('Homeless Often Lack ID', None, 'Travis County', 100),
     ('Lack of Standard Homeless Metrics', None, 'Greater Austin', 3),
-    ('Homelessness', None, u'Lopeño', 0),
+    ('Homelessness', None, 'Lopeño', 0),
     ('Homelessness', None, 'Waxahachie', None),
 ])
 def test_community_model_create(session, problem_name, org_name, geo_name,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import os
 
 import pytest

--- a/tests/geos/test_geo_models.py
+++ b/tests/geos/test_geo_models.py
@@ -1,6 +1,8 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
+
+from intertwine.geos.models import Geo, GeoData, GeoID, GeoLevel
+from intertwine.utils.space import GeoLocation
 
 
 @pytest.mark.unit
@@ -9,8 +11,6 @@ import pytest
 ])
 def test_geo_model_create(session, parent_name, parent_abbrev, child_name):
     """Test simple geo model interaction"""
-    from intertwine.geos.models import Geo
-
     parent = Geo(name=parent_name, abbrev=parent_abbrev)
     child = Geo(name=child_name, path_parent=parent, parents=[parent])
 
@@ -60,8 +60,6 @@ def test_geo_model_create(session, parent_name, parent_abbrev, child_name):
 @pytest.mark.smoke
 def test_geo_data_model(session):
     """Test simple geo data model interaction"""
-    from intertwine.geos.models import Geo, GeoData
-
     total_pop, urban_pop = 1000, 800
     latitude, longitude = 30.0, -97.0
     land_area, water_area = 4321, 1234
@@ -103,8 +101,6 @@ def test_geo_data_model(session):
 @pytest.mark.smoke
 def test_geo_level_model(session):
     """Test simple geo level model interaction"""
-    from intertwine.geos.models import Geo, GeoLevel
-
     level = 'place'
     designation = 'city'
     geo = Geo(name='Test Geo Place')
@@ -134,8 +130,6 @@ def test_geo_level_model(session):
 @pytest.mark.smoke
 def test_geo_id_model(session):
     """Test simple geo id model interaction"""
-    from intertwine.geos.models import Geo, GeoLevel, GeoID
-
     TEST_STANDARD = 'Test Standard'
 
     GeoID.STANDARDS.add(TEST_STANDARD)
@@ -171,9 +165,6 @@ def test_geo_id_model(session):
 @pytest.mark.smoke
 def test_form_aggregate_geo(session):
     """Test geo creation that aggregates children data at a geo level"""
-    from intertwine.geos.models import Geo, GeoData, GeoLevel
-    from intertwine.utils.space import GeoLocation
-
     data_level = 'place'
 
     child_a_dict = {'total_pop': 100,
@@ -264,8 +255,6 @@ def test_form_aggregate_geo(session):
 @pytest.mark.smoke
 def test_geo_aliases(session):
     """Test creation of geo aliases and promoting an alias"""
-    from intertwine.geos.models import Geo, GeoData, GeoLevel
-
     geo_data_dict = {'total_pop': 100,
                      'urban_pop': 80,
                      'latitude': 42,

--- a/tests/problems/test_problem_decode.py
+++ b/tests/problems/test_problem_decode.py
@@ -1,17 +1,19 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
 import pytest
 
 import settings
+from data.data_process import decode
+from intertwine.geos.models import Geo
+from intertwine.problems.models import (
+    Problem, ProblemConnection, ProblemConnectionRating)
+from intertwine.trackable import Trackable
 
 PROBLEM_DATA_DIRECTORY = os.path.join(settings.PROJECT_ROOT, 'data/problems')
 
 
 def create_geo_data(session):
     """Util to create geos referenced in problem JSON"""
-    from intertwine.geos.models import Geo
-
     assert Geo.query.all() == []
     us = Geo(name='United States', abbrev='U.S.')
     tx = Geo(name='Texas', abbrev='TX', path_parent=us, parents=[us])
@@ -26,9 +28,6 @@ def create_geo_data(session):
 @pytest.mark.smoke
 def test_decode_problem(session):
     """Test decoding a standard problem"""
-    from intertwine.problems.models import Problem
-    from data.data_process import decode
-
     assert session is not None
     assert Problem.query.all() == []
 
@@ -56,9 +55,6 @@ def test_decode_problem(session):
 # @pytest.mark.xfail(reason='python3 unicode issue')
 def test_decode_problem_connection(session):
     """Test decoding a standard problem connection"""
-    from intertwine.problems.models import Problem, ProblemConnection
-    from data.data_process import decode
-
     assert session is not None
     assert Problem.query.all() == []
     assert ProblemConnection.query.all() == []
@@ -90,10 +86,6 @@ def test_decode_problem_connection(session):
 # @pytest.mark.xfail(reason='python3 unicode issue')
 def test_decode_problem_connection_rating(session):
     """Test decoding ratings on a single problem connection"""
-    from intertwine.problems.models import (Problem, ProblemConnection,
-                                            ProblemConnectionRating)
-    from data.data_process import decode
-
     create_geo_data(session)
 
     u = decode(session, PROBLEM_DATA_DIRECTORY)  # Decode entire directory
@@ -121,12 +113,6 @@ def test_decode_problem_connection_rating(session):
 # @pytest.mark.xfail(reason='python3 unicode issue')
 def test_incremental_decode(session):
     """Test decoding multiple files incrementally"""
-    from intertwine.trackable import Trackable
-    from intertwine.geos.models import Geo
-    from intertwine.problems.models import (Problem, ProblemConnection,
-                                            ProblemConnectionRating)
-    from data.data_process import decode
-
     create_geo_data(session)
 
     # Initial data load:
@@ -210,10 +196,6 @@ def test_incremental_decode(session):
 @pytest.mark.smoke
 def test_decode_same_data(session):
     """Test decoding incrementally"""
-    from intertwine.trackable import Trackable
-    from intertwine.problems.models import Problem
-    from data.data_process import decode
-
     create_geo_data(session)
 
     json_path = os.path.join(PROBLEM_DATA_DIRECTORY, 'problems02.json')

--- a/tests/problems/test_problem_models.py
+++ b/tests/problems/test_problem_models.py
@@ -1,14 +1,16 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
+
+from intertwine.communities.models import Community
+from intertwine.geos.models import Geo
+from intertwine.problems.models import (
+    Image, Problem, ProblemConnection, ProblemConnectionRating, AggregateProblemConnectionRating)
 
 
 @pytest.mark.unit
 @pytest.mark.smoke
 def test_problem_model(session):
     """Tests simple problem model interaction"""
-    from intertwine.problems.models import Image, Problem
-
     problem_name = 'This is a Test Problem'
     problem = Problem(problem_name)
     assert Problem[problem.derive_key()] is problem
@@ -21,8 +23,6 @@ def test_problem_model(session):
 @pytest.mark.smoke
 def test_problem_connection_model(session):
     """Tests simple problem connection model interaction"""
-    from intertwine.problems.models import Problem, ProblemConnection
-
     problem_name_base = 'Test Problem'
     problem1 = Problem(problem_name_base + ' 01')
     problem2 = Problem(problem_name_base + ' 02')
@@ -47,11 +47,6 @@ def test_problem_connection_model(session):
 @pytest.mark.smoke
 def test_problem_connection_rating_model(session):
     """Tests simple problem connection rating model interaction"""
-    from intertwine.geos.models import Geo
-    from intertwine.problems.models import (Problem,
-                                            ProblemConnection,
-                                            ProblemConnectionRating)
-
     problem_name_base = 'Test Problem'
     problem1 = Problem(problem_name_base + ' 01')
     problem2 = Problem(problem_name_base + ' 02')
@@ -88,13 +83,6 @@ def test_problem_connection_rating_model(session):
 @pytest.mark.smoke
 def test_aggregate_problem_connection_rating_model(session):
     """Tests aggregate problem connection rating model interaction"""
-    from intertwine.communities.models import Community
-    from intertwine.geos.models import Geo
-    from intertwine.problems.models import (Problem,
-                                            ProblemConnection,
-                                            ProblemConnectionRating,
-                                            AggregateProblemConnectionRating)
-
     problem_name_base = 'Test Problem'
     problem1 = Problem(problem_name_base + ' 01')
     problem2 = Problem(problem_name_base + ' 02')

--- a/tests/problems/test_problem_views.py
+++ b/tests/problems/test_problem_views.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import json
 import pytest
-import sys
 
 from intertwine.communities.models import Community
 from intertwine.geos.models import Geo
@@ -9,9 +8,6 @@ from intertwine.problems.models import Problem
 from intertwine.problems.models import ProblemConnection as PC
 from intertwine.problems.models import AggregateProblemConnectionRating as APCR
 from intertwine.utils.vardygr import vardygrify
-
-# Python version compatibilities
-U_LITERAL = 'u' if sys.version_info < (3,) else ''
 
 
 @pytest.mark.unit
@@ -23,12 +19,6 @@ U_LITERAL = 'u' if sys.version_info < (3,) else ''
 def test_add_rated_problem_connection(session, client, connection_category,
                                       is_real_community):
     """Tests aggregate problem connection rating model interaction"""
-    import json
-
-    # from intertwine.communities.models import Community
-    # from intertwine.geos.models import Geo
-    # from intertwine.problems.models import Problem, ProblemConnection
-
     problem_name_base = 'Test Problem'
     problem1 = Problem(problem_name_base + ' 01')
     org = 'University of Texas'

--- a/tests/test_bases.py
+++ b/tests/test_bases.py
@@ -1,17 +1,15 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
 
+from intertwine import IntertwineModel
+from intertwine.trackable import Trackable
+from intertwine.utils.enums import UriType
 from tests.builders.master import Builder
 
 
 @pytest.mark.unit
 def test_uri_formation_and_instantiation(session):
     """Test URI formation and instantiation"""
-    from intertwine.trackable import Trackable
-    from intertwine import IntertwineModel
-    from intertwine.utils.enums import UriType
-
     for class_name, cls in Trackable._classes.items():
         # Register existing for builders since registry is cleared below
         Trackable.register_existing(session)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,15 +1,16 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import os
 import pytest
+
+import flask
+
+from intertwine import create_app
 
 
 @pytest.mark.unit
 @pytest.mark.smoke
 def test_app_created(options):
     """Test that a working app is created"""
-    import flask
-    from intertwine import create_app
-
     config = options['config']
     app = create_app(config=config)
     assert 'SERVER_NAME' in app.config
@@ -27,9 +28,6 @@ def test_app_created(options):
 @pytest.mark.smoke
 def test_database_created(options):
     """Test that database is created"""
-    import os
-    from intertwine import create_app
-
     # Find the database file
     config = options['config']
     app = create_app(config=config)

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 import pkg_resources
 import pytest
 import sys

--- a/tests/test_singleton_blueprints.py
+++ b/tests/test_singleton_blueprints.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from intertwine.utils.blueprints import create_singleton_blueprint
 
 
 def test_singleton_blueprints():
-    from intertwine.utils.blueprints import create_singleton_blueprint
-
     x = create_singleton_blueprint('example', __name__)
     y = create_singleton_blueprint('example', __name__)
     assert(x == y)

--- a/tests/test_singletons.py
+++ b/tests/test_singletons.py
@@ -1,12 +1,12 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
+
+from intertwine.utils.blueprints import create_singleton_blueprint
+from intertwine.utils.decorators import memoize, singleton
 
 
 @pytest.mark.skip('Feature not ready')
 def test_singleton_blueprints():
-    from intertwine.utils.blueprints import create_singleton_blueprint
-
     x = create_singleton_blueprint('example', __name__)
     y = create_singleton_blueprint('example', __name__)
     assert(x == y)
@@ -18,8 +18,6 @@ def test_singleton_blueprints():
 
 @pytest.mark.skip('Feature not ready')
 def test_singleton_decorator():
-    from intertwine.utils.decorators import singleton
-
     @singleton(parametric=True)
     def test(*args, **kwds):
         print('hi')
@@ -31,8 +29,6 @@ def test_singleton_decorator():
 
 
 def test_memoize_decorator():
-    from intertwine.utils.decorators import memoize
-
     @memoize
     def test(*args, **kwds):
         print('hi')

--- a/tests/test_trackable.py
+++ b/tests/test_trackable.py
@@ -1,15 +1,15 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
 
+from intertwine.problems.models import Problem
+from intertwine.trackable import Trackable
+from intertwine.trackable.exceptions import KeyMissingFromRegistryAndDatabase
 from tests.builders.master import Builder
 
 
 @pytest.mark.unit
 def test_trackable_class_keys(session):
     """Test Trackable Class Keys"""
-    from intertwine.trackable import Trackable
-
     for class_name, cls in Trackable._classes.items():
         key_class_name = cls.Key.__name__.split('Key')[0]
         assert key_class_name == class_name
@@ -27,8 +27,6 @@ def test_trackable_class_keys(session):
 @pytest.mark.unit
 def test_trackable_deconstruction_reconstruction(session):
     """Test Trackable Deconstruction & Reconstruction"""
-    from intertwine.trackable import Trackable
-
     for class_name, cls in Trackable._classes.items():
         builder = Builder(cls, optional=False)
         inst = builder.build()
@@ -80,9 +78,6 @@ def test_trackable_deconstruction_reconstruction(session):
 @pytest.mark.unit
 def test_trackable_tget(session):
     """Test Trackable get (tget)"""
-    from intertwine.problems.models import Problem
-    from intertwine.trackable import Trackable
-
     problem_name = 'Test Problem'
     problem_key = Problem.create_key(name='Test Problem')
     assert len(problem_key) == 1
@@ -131,11 +126,6 @@ def test_trackable_tget(session):
 @pytest.mark.unit
 def test_trackable_indexability(session):
     """Test Trackable indexability (via []s)"""
-    from intertwine.problems.models import Problem
-    from intertwine.trackable import Trackable
-    from intertwine.trackable.exceptions import (
-        KeyMissingFromRegistryAndDatabase)
-
     problem_name = 'Test Problem'
     problem_key = Problem.create_key(name='Test Problem')
     assert len(problem_key) == 1

--- a/tests/utils/test_analytics.py
+++ b/tests/utils/test_analytics.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
 from itertools import tee

--- a/tests/utils/test_duck_typing.py
+++ b/tests/utils/test_duck_typing.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
 from collections import namedtuple

--- a/tests/utils/test_flex_time.py
+++ b/tests/utils/test_flex_time.py
@@ -1,10 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import pytest
-import sys
 from datetime import datetime
 
 from pendulum import DateTime, timezone
@@ -72,28 +67,18 @@ def test_flex_time_instantiation(
         tz_instance=True)
 
     dt_native_kwargs = dt_info_native._asdict()
-    if sys.version_info < (3, 6):
-        del dt_native_kwargs[FlexTime.FOLD_TAG]
     native_dt = datetime(**dt_native_kwargs)
 
     dt_native_args = dt_info_native[:FlexTime.FOLD_IDX]
-    if sys.version_info < (3, 6):
-        native_dt_via_args = datetime(*dt_native_args)
-    else:
-        native_dt_via_args = datetime(fold=fold, *dt_native_args)
+    native_dt_via_args = datetime(fold=fold, *dt_native_args)
     assert native_dt == native_dt_via_args
 
     dt_naive_kwargs = dt_info_native._asdict()
-    if sys.version_info < (3, 6):
-        del dt_naive_kwargs[FlexTime.FOLD_TAG]
     del dt_naive_kwargs[FlexTime.TZINFO_TAG]
     naive_dt = datetime(**dt_naive_kwargs)
 
     dt_naive_args = dt_info_native[:FlexTime.TZINFO_IDX]
-    if sys.version_info < (3, 6):
-        naive_dt_via_args = datetime(*dt_naive_args)
-    else:
-        naive_dt_via_args = datetime(fold=fold, *dt_naive_args)
+    naive_dt_via_args = datetime(fold=fold, *dt_naive_args)
     assert naive_dt == naive_dt_via_args
 
     # base_dt = DateTime(**dt_info_with_defaults._asdict())
@@ -149,8 +134,6 @@ def test_core_flex_time_interactions(
         tz_instance=True)
 
     dt_native_kwargs = dt_info_native._asdict()
-    if sys.version_info < (3, 6):
-        del dt_native_kwargs[FlexTime.FOLD_TAG]
 
     native_dt = datetime(**dt_native_kwargs)
     base_dt = DateTime(**dt_info_native._asdict())

--- a/tests/utils/test_jsonable.py
+++ b/tests/utils/test_jsonable.py
@@ -1,9 +1,6 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import json
+
 import pytest
 
 
@@ -15,7 +12,7 @@ import pytest
     ('Sexual Assault', 'University of Texas', 'Austin', 5000),
     ('Homeless Often Lack ID', None, 'Travis County', 100),
     ('Lack of Standard Homeless Metrics', None, 'Greater Austin', 3),
-    ('Homelessness', None, u'Lopeño', 0),
+    ('Homelessness', None, 'Lopeño', 0),
     ('Homelessness', None, 'Waxahachie', None),
 ])
 def test_jsonify(session, problem_name, org_name, geo_name, num_followers):
@@ -64,7 +61,7 @@ def test_jsonify(session, problem_name, org_name, geo_name, num_followers):
     ('Sexual Assault', 'University of Texas', 'Austin', 5000),
     ('Homeless Often Lack ID', None, 'Travis County', 100),
     ('Lack of Standard Homeless Metrics', None, 'Greater Austin', 3),
-    ('Homelessness', None, u'Lopeño', 0),
+    ('Homelessness', None, 'Lopeño', 0),
     ('Homelessness', None, 'Waxahachie', None),
 ])
 def test_jsonify_depth2(session, problem_name, org_name, geo_name,

--- a/tests/utils/test_quantized.py
+++ b/tests/utils/test_quantized.py
@@ -1,33 +1,23 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-import pytest
-import sys
 from decimal import Decimal
 
-from intertwine.utils.quantized import QuantizedDecimal
+import pytest
 
-# Python version compatibilities
-if sys.version_info >= (3,):
-    long = int
-    unicode = str
+from intertwine.utils.quantized import QuantizedDecimal
 
 ABS = 'abs(a)'
 COMPLEX = 'complex(a)'
 DIVMOD = 'divmod(a, b)'
 FLOAT = 'float(a)'
 INT = 'int(a)'
-LONG = 'long(a)'
 POW = 'pow(a, b)'
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize('number', [
     str('3.14159265359'),
-    unicode('3.14159265359'),
     float(3.14159265359),
-    long(98765432109876543210),
+    98765432109876543210,
     42,
 ])
 @pytest.mark.parametrize('precision', [None, 0, 1, 7])
@@ -174,7 +164,7 @@ def test_quantized_decimal_unary_math(operator, number, precision):
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize('operator', [COMPLEX, FLOAT, INT, LONG])
+@pytest.mark.parametrize('operator', [COMPLEX, FLOAT, INT])
 @pytest.mark.parametrize('number', [2 ** 63 + 0.1234567])
 @pytest.mark.parametrize('precision', [7])
 def test_quantized_decimal_type_cast(operator, number, precision):

--- a/tests/utils/test_space.py
+++ b/tests/utils/test_space.py
@@ -1,17 +1,9 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-import pytest
-import sys
 from decimal import Decimal
 
-from intertwine.utils.space import Area, Coordinate, GeoLocation
+import pytest
 
-# Python version compatibilities
-if sys.version_info >= (3,):
-    long = int
-    unicode = str
+from intertwine.utils.space import Area, Coordinate, GeoLocation
 
 
 def perform_core_quantized_interactions(cls, number):
@@ -44,8 +36,8 @@ def perform_core_quantized_interactions(cls, number):
 @pytest.mark.parametrize('number', [
     str('0.123456'),
     float(987654321.123456),
-    int(512),
-    long(98765432109876543210),
+    512,
+    98765432109876543210,
     0
 ])
 def test_area_core_interactions(number):
@@ -57,8 +49,8 @@ def test_area_core_interactions(number):
 @pytest.mark.parametrize('number', [
     str('0.1234567890'),
     float(12.1234567890),
-    int(-90),
-    long(90),
+    -90,
+    90,
     0
 ])
 def test_coordinate_core_interactions(number):

--- a/tests/utils/test_structures.py
+++ b/tests/utils/test_structures.py
@@ -1,15 +1,11 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
-import pytest
 import random
 from collections import OrderedDict, namedtuple
 from random import choice
 
-from intertwine.utils.structures import (InsertableOrderedDict, MultiKeyMap,
-                                         Sentinel)
+import pytest
+
+from intertwine.utils.structures import InsertableOrderedDict, MultiKeyMap, Sentinel
 from intertwine.utils.tools import nth_item
 
 

--- a/tests/utils/test_tools.py
+++ b/tests/utils/test_tools.py
@@ -1,14 +1,12 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
+import inspect
 import json
 import pytest
 from collections import OrderedDict, namedtuple
 from decimal import Decimal
 from enum import Enum, IntEnum
-from past.builtins import basestring
+
+from intertwine.utils.tools import TEXT_TYPES
 
 MyNamedTuple = namedtuple('MyNamedTuple', 'first second third')
 
@@ -47,15 +45,13 @@ def type_annotated_fn(
 @pytest.mark.unit
 def test_derive_arg_types():
     """Test Derive Kwarg Types"""
-    from intertwine.utils.tools import (ANNOTATION_TYPE_MAP,
-                                        derive_arg_types, gethalffullargspec)
+    from intertwine.utils.tools import ANNOTATION_TYPE_MAP, derive_arg_types
 
     custom = (CrosswalkSignal, TrafficSignal)
     custom_map = {typ_.__name__: typ_ for typ_ in custom}
 
     arg_type_generator = derive_arg_types(type_annotated_fn, custom=custom)
-
-    args = gethalffullargspec(type_annotated_fn).args
+    args = inspect.getfullargspec(type_annotated_fn).args
 
     start = 1 if args[0] in {'self', 'cls', 'meta'} else 0
 
@@ -128,7 +124,7 @@ def test_stringify(limit):
                 assert str(k) in stringified_value
                 assert str(v) in stringified_value
         elif (isiterable(standardized_value) and
-                not isinstance(standardized_value, basestring)):
+                not isinstance(standardized_value, TEXT_TYPES)):
             standardized_length = len(standardized_value)
             length = standardized_length if limit < 0 else min(limit, standardized_length)
             for i, v in enumerate(standardized_value):
@@ -150,7 +146,7 @@ def test_stringify(limit):
     ('Sexual Assault', 'University of Texas', 'Austin', 5000),
     ('Homeless Often Lack ID', None, 'Travis County', 100),
     ('Lack of Standard Homeless Metrics', None, 'Greater Austin', 3),
-    ('Homelessness', None, u'Lopeño', 0),
+    ('Homelessness', None, 'Lopeño', 0),
     ('Homelessness', None, 'Waxahachie', None),
 ])
 def test_vardygrify(session, problem_name, org_name, geo_name, num_followers):


### PR DESCRIPTION
Clean up legacy Python 2 code
- Remove Python 2 conditional imports
- Remove `__future__` imports
- Remove unicode literal usages
- Replace basestring usages with str or TEXT_TYPES
- Remove object as base class
- Update script shebangs to python3
- Remove shebang from non-scripts

Also, move most test imports to module level