### PR TITLE
Disable instance caching by default

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -105,3 +105,10 @@ def client(app, request):
 
     request.addfinalizer(teardown)
     return client
+
+
+@pytest.fixture(scope='function')
+def caching(app, request):
+    """Enable caching of model instances"""
+    with Trackable.caching():
+        yield

--- a/tests/problems/test_problem_decode.py
+++ b/tests/problems/test_problem_decode.py
@@ -26,7 +26,7 @@ def create_geo_data(session):
 
 @pytest.mark.unit
 @pytest.mark.smoke
-def test_decode_problem(session):
+def test_decode_problem(session, caching):
     """Test decoding a standard problem"""
     assert session is not None
     assert Problem.query.all() == []
@@ -53,7 +53,7 @@ def test_decode_problem(session):
 @pytest.mark.unit
 @pytest.mark.smoke
 # @pytest.mark.xfail(reason='python3 unicode issue')
-def test_decode_problem_connection(session):
+def test_decode_problem_connection(session, caching):
     """Test decoding a standard problem connection"""
     assert session is not None
     assert Problem.query.all() == []
@@ -84,7 +84,7 @@ def test_decode_problem_connection(session):
 @pytest.mark.unit
 @pytest.mark.smoke
 # @pytest.mark.xfail(reason='python3 unicode issue')
-def test_decode_problem_connection_rating(session):
+def test_decode_problem_connection_rating(session, caching):
     """Test decoding ratings on a single problem connection"""
     create_geo_data(session)
 
@@ -111,7 +111,7 @@ def test_decode_problem_connection_rating(session):
 @pytest.mark.unit
 @pytest.mark.smoke
 # @pytest.mark.xfail(reason='python3 unicode issue')
-def test_incremental_decode(session):
+def test_incremental_decode(session, caching):
     """Test decoding multiple files incrementally"""
     create_geo_data(session)
 
@@ -194,7 +194,7 @@ def test_incremental_decode(session):
 
 @pytest.mark.unit
 @pytest.mark.smoke
-def test_decode_same_data(session):
+def test_decode_same_data(session, caching):
     """Test decoding incrementally"""
     create_geo_data(session)
 

--- a/tests/problems/test_problem_models.py
+++ b/tests/problems/test_problem_models.py
@@ -13,10 +13,10 @@ def test_problem_model(session):
     """Tests simple problem model interaction"""
     problem_name = 'This is a Test Problem'
     problem = Problem(problem_name)
-    assert Problem[problem.derive_key()] is problem
     session.add(problem)
     session.commit()
     assert session.query(Problem).first() is problem
+    assert Problem[problem.derive_key()] is problem
 
 
 @pytest.mark.unit
@@ -27,11 +27,11 @@ def test_problem_connection_model(session):
     problem1 = Problem(problem_name_base + ' 01')
     problem2 = Problem(problem_name_base + ' 02')
     connection = ProblemConnection('causal', problem1, problem2)
-    assert ProblemConnection[connection.derive_key()] is connection
     session.add(problem1)
     session.add(problem2)
     session.add(connection)
     session.commit()
+    assert ProblemConnection[connection.derive_key()] is connection
     problems = session.query(Problem).order_by(Problem.name).all()
     assert len(problems) == 2
     assert problems[0] is problem1
@@ -61,13 +61,13 @@ def test_problem_connection_rating_model(session):
                                      geo=geo,
                                      user='new_user')
 
-    assert ProblemConnectionRating[rating.derive_key()] is rating
     session.add(geo)
     session.add(problem1)
     session.add(problem2)
     session.add(connection)
     session.add(rating)
     session.commit()
+    assert ProblemConnectionRating[rating.derive_key()] is rating
     ratings = session.query(ProblemConnectionRating).all()
     assert len(ratings) == 1
     r = ratings[0]

--- a/tests/test_bases.py
+++ b/tests/test_bases.py
@@ -8,7 +8,7 @@ from intertwine.utils.enums import UriType
 from tests.builders.master import Builder
 
 @pytest.mark.unit
-def test_uri_formation_and_instantiation(session):
+def test_uri_formation_and_instantiation(session, caching):
     """Test URI formation and instantiation"""
     for class_name, cls in Trackable._classes.items():
         # Register existing for builders since registry is cleared below
@@ -32,7 +32,7 @@ def test_uri_formation_and_instantiation(session):
 
 
 @pytest.mark.unit
-def test_uri_formation_and_instantiation_with_null_query_value(session):
+def test_uri_formation_and_instantiation_with_null_query_value(session, caching):
     """Test URI formation and instantiation"""
     cls = Community
     # Register existing for builders since registry is cleared below

--- a/tests/test_trackable.py
+++ b/tests/test_trackable.py
@@ -9,7 +9,7 @@ from tests.builders.master import Builder
 
 
 @pytest.mark.unit
-def test_trackable_class_keys(session):
+def test_trackable_class_keys(session, caching):
     """Test Trackable Class Keys"""
     for class_name, cls in Trackable._classes.items():
         key_class_name = cls.Key.__name__.split('Key')[0]
@@ -27,7 +27,7 @@ def test_trackable_class_keys(session):
 
 @pytest.mark.unit
 @pytest.mark.parametrize('org_is_null', [(False,), (True,)])
-def test_trackable_deconstruction_reconstruction(session, org_is_null):
+def test_trackable_deconstruction_reconstruction(session, caching, org_is_null):
     """Test Trackable Deconstruction & Reconstruction"""
     for class_name, cls in Trackable._classes.items():
         builder = Builder(cls, optional=False)
@@ -72,7 +72,7 @@ def test_trackable_deconstruction_reconstruction(session, org_is_null):
 
 
 @pytest.mark.unit
-def test_trackable_tget(session):
+def test_trackable_tget(session, caching):
     """Test Trackable get (tget)"""
     problem_name = 'Test Problem'
     problem_key = Problem.create_key(name='Test Problem')
@@ -120,7 +120,7 @@ def test_trackable_tget(session):
 
 
 @pytest.mark.unit
-def test_trackable_indexability(session):
+def test_trackable_indexability(session, caching):
     """Test Trackable indexability (via []s)"""
     problem_name = 'Test Problem'
     problem_key = Problem.create_key(name='Test Problem')


### PR DESCRIPTION
- disable Trackable's instance caching
- refactor Trackable's tget to simplify logic
- add Trackable.caching context manager to enable caching in limited use cases
- increase Trackable's trepr max width to 99